### PR TITLE
Using JsDoc from other directories

### DIFF
--- a/jsdoc
+++ b/jsdoc
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-#BASEDIR=`dirname $0`
-java -classpath js.jar org.mozilla.javascript.tools.shell.Main jsdoc.js $@
+BASEDIR=$(cd $(dirname $(readlink -f "$0")) && pwd)
+java -classpath $BASEDIR/js.jar org.mozilla.javascript.tools.shell.Main $BASEDIR/jsdoc.js $@

--- a/jsdoc.js
+++ b/jsdoc.js
@@ -12,7 +12,9 @@
     @type string
     @global
  */
-const BASEDIR = './';
+var opt = { output: "" };
+runCommand( "dirname", java.lang.System.getProperty( "java.class.path" ), opt );
+const BASEDIR = opt.output.replace(/[\r\n]/g, "") + "/";
 
 /** Include a JavaScript module, defined in the CommonJS way.
     @param {string} id The identifier of the module you require.


### PR DESCRIPTION
It's inconvenient to have to switch directories to generate documentation. This small change to jsdoc and jsdoc.js works regardless of cwd and with symlinks (e.g. from /usr/bin).

If the way BASEDIR is defined in jsdoc.js is cumbersome/ugly/inelegant, the other option is to define it as
`const BASEDIR = java.lang.System.getProperty("java.class.path").replace( /[^\/]+$/, "");`
and eliminate the `var opt` and `runCommand` lines.
