### PR TITLE
Fix for class documentation

### DIFF
--- a/templates/default/publish.js
+++ b/templates/default/publish.js
@@ -237,7 +237,7 @@
             nav = nav + '<h3>Classes</h3><ul>';
             classNames.forEach(function(c) {
                 var moduleSameName = data.get( data.find({kind: 'module', longname: c.longname}) );
-                if (moduleSameName) {
+                if (moduleSameName.length) {
                     c.name = c.name.replace('module:', 'require(')+')';
                     moduleSameName[0].module = c;
                 }


### PR DESCRIPTION
On line 239 of publish.js, we get modules with the same name of a class. However, if no matching modules are found, it returns an empty array. However, line 240 only checks if the array exists; not if it has any values.

This fixes that issue.
