### PR TITLE
@abstract/@virtual tag support.

### DIFF
--- a/rhino_modules/jsdoc/schema.js
+++ b/rhino_modules/jsdoc/schema.js
@@ -113,6 +113,11 @@ exports.jsdocSchema = {
                         "maxItems": 1,
                         "enum": ["private", "protected", "public"]
                     },
+                    "virtual": { // is a member left to be implemented during inheritance?
+                        "type": "boolean",
+                        "optional": true,
+                        "default": false
+                    },
                     "attrib": { // other attributes, like "readonly"
                         "type": "string",
                         "optional": true

--- a/rhino_modules/jsdoc/tag/dictionary/definitions.js
+++ b/rhino_modules/jsdoc/tag/dictionary/definitions.js
@@ -11,6 +11,15 @@
 */
 exports.defineTags = function(dictionary) {
     
+    dictionary.defineTag('abstract', {
+        mustNotHaveValue: true,
+        onTagged: function(doclet, tag) {
+            // since "abstract" is reserved word in JavaScript let's use "virtual" in code
+            doclet.virtual = true;
+        }
+    })
+    .synonym('virtual');
+    
     dictionary.defineTag('access', {
         mustHaveValue: true,
         onTagged: function(doclet, tag) {

--- a/templates/default/publish.js
+++ b/templates/default/publish.js
@@ -102,6 +102,10 @@
         function addAttribs(f) {
             var attribs = [];
             
+            if (f.virtual) {
+                attribs.push('virtual');
+            }
+            
             if (f.access && f.access !== 'public') {
                 attribs.push(f.access);
             }

--- a/templates/haruki/publish.js
+++ b/templates/haruki/publish.js
@@ -51,7 +51,8 @@
                 var thisNamespace = parentNode.namespaces[element.name] = {
                     'name': element.name,
                     'description': element.description || '',
-                    'access': element.access || ''
+                    'access': element.access || '',
+                    'virtual': !!element.virtual
                 };
                 
                 graft(thisNamespace, childNodes, element.longname, element.name);
@@ -64,7 +65,8 @@
                 var thisMixin = parentNode.mixins[element.name] = {
                     'name': element.name,
                     'description': element.description || '',
-                    'access': element.access || ''
+                    'access': element.access || '',
+                    'virtual': !!element.virtual
                 };
                 
                 graft(thisMixin, childNodes, element.longname, element.name);
@@ -77,6 +79,7 @@
                 var thisFunction = parentNode.functions[element.name] = {
                     'name': element.name,
                     'access': element.access || '',
+                    'virtual': !!element.virtual,
                     'description': element.description || '',
                     'parameters': [ ]
                 };
@@ -108,6 +111,7 @@
                 parentNode.properties[element.name] = {
                     'name': element.name,
                     'access': element.access || '',
+                    'virtual': !!element.virtual,
                     'description': element.description || '',
                     'type': element.type? (element.type.length === 1? element.type[0] : element.type) : ''
                 };
@@ -121,6 +125,7 @@
                 var thisEvent = parentNode.events[element.name] = {
                     'name': element.name,
                     'access': element.access || '',
+                    'virtual': !!element.virtual,
                     'description': element.description || '',
                     'parameters': [
                     ]
@@ -156,6 +161,7 @@
                     'description': element.classdesc || '',
                     'extends': element.augments || [],
                     'access': element.access || '',
+                    'virtual': !!element.virtual,
                     'fires': element.fires || '',
                     'constructor': {
                         'name': element.name,

--- a/test/cases/abstracttag.js
+++ b/test/cases/abstracttag.js
@@ -1,0 +1,17 @@
+/** @constructor */
+function Thingy() {
+
+    /** @abstract */
+    this.pez = 2;
+    
+}
+
+// same as...
+
+/** @constructor */
+function OtherThingy() {
+
+    /** @virtual */
+    this.pez = 2;
+    
+}

--- a/test/runner.js
+++ b/test/runner.js
@@ -103,6 +103,7 @@ testFile('test/t/cases/innerscope2.js');
 testFile('test/t/cases/modules/data/mod-1.js');
 testFile('test/t/cases/modules/data/mod-2.js');
 
+testFile('test/t/cases/abstracttag.js');
 testFile('test/t/cases/accesstag.js');
 testFile('test/t/cases/alias.js');
 testFile('test/t/cases/alias2.js');

--- a/test/t/cases/abstracttag.js
+++ b/test/t/cases/abstracttag.js
@@ -1,0 +1,22 @@
+(function() {
+    var docSet = testhelpers.getDocSetFromFile('test/cases/abstracttag.js'),
+        type = docSet.getByLongname('Thingy')[0]
+        pez = docSet.getByLongname('Thingy#pez')[0];
+    
+    test('By default symbol has virtual=undefined property.', function() {
+        assert.equal(!!type.virtual, false);
+    });
+    
+    test('When a symbol has a @abstract tag, the doclet has a virtual=true property.', function() {
+        assert.equal(pez.virtual, true);
+    });
+    
+    // same as...
+    
+    pez = docSet.getByLongname('OtherThingy#pez')[0];
+    
+    test('When a symbol has a @virtual tag, the doclet has a virtual=true property.', function() {
+        assert.equal(pez.virtual, true);
+    });
+
+})();


### PR DESCRIPTION
I know that abstract members in JavaScript are hardly used and that JavaScript does not support abstractions, but I think it's similar situation to private/protected members.

For documentation purpose, I think there should be a possibility to mark members as @abstract/@virtual. For example to document non-existing method with additional docblock and mark it @virtual for people who want to extend our type.
