### PR TITLE
Dropped template default parameter.

### DIFF
--- a/rhino_modules/jsdoc/opts/parser.js
+++ b/rhino_modules/jsdoc/opts/parser.js
@@ -12,7 +12,6 @@ var common = {
 var argParser = new common.args.ArgParser(),
 	ourOptions,
 	defaults = {
-		template: 'templates/default',
 		destination: './out/'
 	};
 


### PR DESCRIPTION
Default template is hardcoded in jsdoc.js, so there is no need in having it duplicated and default argument value acts like passed argument and overrides options from configuration file.
