### PR TITLE
Mark inherited methods.

### DIFF
--- a/rhino_modules/jsdoc/augment.js
+++ b/rhino_modules/jsdoc/augment.js
@@ -48,6 +48,8 @@
                     members = getMembers(parents[j], docs);
                     for (var k=0, kk=members.length; k<kk; ++k) {
                         member = doop(members[k]);
+                        member.inherits = member.longname;
+                        member.inherited = true;
                         member.memberof = doc.longname;
                         parts = member.longname.split("#");
                         parts[0] = doc.longname;


### PR DESCRIPTION
Making inherited members is a good idea because you can link them in template to show real source.
