### PR TITLE
Exposing alias modifications.

### DIFF
--- a/rhino_modules/jsdoc/src/handlers.js
+++ b/rhino_modules/jsdoc/src/handlers.js
@@ -65,6 +65,7 @@ exports.attachTo = function(parser) {
             newDoclet.addTag('name', e.code.name);
             if (!newDoclet.memberof && e.astnode) {
                 var memberofName,
+                    basename,
                     scope;
                 if ( /^((module.)?exports|this)(\.|$)/.test(newDoclet.name) ) {
                     var nameStartsWith = RegExp.$1;
@@ -102,9 +103,18 @@ exports.attachTo = function(parser) {
                 }
                 else {
                     memberofName = this.astnodeToMemberof(e.astnode);
+                    if (memberofName instanceof Array) {
+                        basename = memberofName[1];
+                        memberofName = memberofName[0];
+                    }
                 }
                 
-                if (memberofName) { newDoclet.addTag( 'memberof', memberofName); }
+                if (memberofName) {
+                    newDoclet.addTag( 'memberof', memberofName);
+                    if (basename) {
+                        newDoclet.name = newDoclet.name.replace(new RegExp('^' + RegExp.escape(basename) + '.'), '');
+                    };
+                }
                 else {
                     if (currentModule) {
                         if (!newDoclet.scope) newDoclet.addTag( 'inner');

--- a/test/cases/aliasresolve.js
+++ b/test/cases/aliasresolve.js
@@ -1,0 +1,19 @@
+/**
+ * @namespace
+ */
+var A = {};
+
+(function(ns) {
+    /**
+     * @namespace
+     * @alias A.F
+     */
+    var f = {};
+
+    /**
+     * @return {String}
+     */
+    f.method = function(){};
+
+    ns.F = f;
+})(A);

--- a/test/runner.js
+++ b/test/runner.js
@@ -99,6 +99,7 @@ testFile('test/t/cases/var.js');
 testFile('test/t/cases/inner.js');
 testFile('test/t/cases/innerscope.js');
 testFile('test/t/cases/innerscope2.js');
+testFile('test/t/cases/aliasresolve.js');
 
 testFile('test/t/cases/modules/data/mod-1.js');
 testFile('test/t/cases/modules/data/mod-2.js');

--- a/test/t/cases/aliasresolve.js
+++ b/test/t/cases/aliasresolve.js
@@ -1,0 +1,8 @@
+(function() {
+    var docSet = testhelpers.getDocSetFromFile('test/cases/aliasresolve.js'),
+        method = docSet.getByLongname('A.F.method');
+
+    test('When a local reference has alias, put all members into aliased definition.', function() {
+        assert.equal(method.length, 1, 'Local modifications are visible to outside.');
+    });
+})();


### PR DESCRIPTION
When a local variable is aliased, all it's modifications should be "exported" to aliased symbol. It's very common case for all closure-based code:

``` javascript
/**
 * @namespace
 */
var A = {};

(function(ns) {
    /**
     * @namespace
     * @alias A.F
     */
    var f = {};

    /**
     * @return {String}
     */
    f.method = function(){};

    ns.F = f;
})(A);
```

This patch does the work. Returning second parameter from Parser.astnodeToMemberof is not so elegant, but I didn't want to change flow - we would need to pass doclet as parameter to operate on it.
