### PR TITLE
Properly inherit members from grandparents.

### DIFF
--- a/rhino_modules/jsdoc/augment.js
+++ b/rhino_modules/jsdoc/augment.js
@@ -4,18 +4,17 @@
     exports.addInherited = function(docs) {
         var dependencies = mapDependencies(docs.index);
         var sorted = sort(dependencies);
-        var additions = [];
         sorted.forEach(function(name) {
             var doclets = docs.index[name];
-            Array.prototype.push.apply(additions, getAdditions(doclets, docs));
-        });
-        additions.forEach(function(doc) {
-            var name = doc.longname;
-            if (!(docs.index.hasOwnProperty(name))) {
-                docs.index[name] = [];
-            }
-            docs.index[name].push(doc);
-            docs.push(doc);
+            var additions = getAdditions(doclets, docs);
+            additions.forEach(function(doc) {
+                var name = doc.longname;
+                if (!(docs.index.hasOwnProperty(name))) {
+                    docs.index[name] = [];
+                }
+                docs.index[name].push(doc);
+                docs.push(doc);
+            });
         });
     }
 

--- a/test/README.md
+++ b/test/README.md
@@ -1,3 +1,3 @@
 From the project root, run the following command in the terminal:
 
-    java -jar lib/js.jar jsdoc.js -T
+    java -jar lib/js.jar -modules rhino_modules -modules node_modules jsdoc.js -T

--- a/test/cases/augmentstag.js
+++ b/test/cases/augmentstag.js
@@ -25,7 +25,7 @@ Foo.prototype.method2 = function() {};
 
 /**
  * @constructor
- *  @extends Foo
+ * @extends Foo
  */
 function Bar() {
     /** Thrid prop **/
@@ -36,4 +36,18 @@ function Bar() {
  * Second child method.
  */
 Bar.prototype.method2 = function() {};
+
+/**
+ * @constructor
+ * @extends Bar
+ */
+function Baz() {
+    /** Override prop1 */
+    this.prop1 = "new";
+}
+
+/**
+ * Third grandchild method.
+ */
+Baz.prototype.method3 = function() {};
 

--- a/test/t/cases/augmentstag.js
+++ b/test/t/cases/augmentstag.js
@@ -12,6 +12,12 @@
         barProp3 = docSet.getByLongname('Bar#prop3')[0],
         barMethod1 = docSet.getByLongname('Bar#method1')[0],
         barMethod2 = docSet.getByLongname('Bar#method2')[0];
+        bazProp1 = docSet.getByLongname('Baz#prop1')[0],
+        bazProp2 = docSet.getByLongname('Baz#prop2')[0],
+        bazProp3 = docSet.getByLongname('Baz#prop3')[0],
+        bazMethod1 = docSet.getByLongname('Baz#method1')[0],
+        bazMethod2 = docSet.getByLongname('Baz#method2')[0];
+        bazMethod3 = docSet.getByLongname('Baz#method3')[0];
     
     test('When a symbol has an @augments tag, the doclet has a augments property that includes that value.', function() {
         assert.equal(typeof bar.augments, 'object');
@@ -45,6 +51,16 @@
         assert.equal(fooMethod2.description, "Second parent method.");
         assert.equal(barMethod2.memberof, "Bar");
         assert.equal(barMethod2.description, "Second child method.");
+    });
+
+    test('When an object is extended, it inherits properties set on grandparent prototype', function() {
+        assert.equal(fooProp1.memberof, "Foo");
+        assert.equal(barProp1.memberof, "Bar");
+        assert.equal(bazProp1.memberof, "Baz");
+        assert.equal(bazProp1.description, "Override prop1");
+        assert.equal(bazMethod1.memberof, "Baz");
+        assert.equal(bazMethod2.memberof, "Baz");
+        assert.equal(bazMethod3.memberof, "Baz");
     });
 
 


### PR DESCRIPTION
Previously, inheritance only worked one level deep.  With this change, inherited members are added to the docs after processing each doclet.  This allows for proper inheritance to an arbitrary depth.
