### PR TITLE
Always making source file list available to templates

### DIFF
--- a/jsdoc.js
+++ b/jsdoc.js
@@ -213,11 +213,11 @@ function main() {
         
         docs = app.jsdoc.parser.parse(sourceFiles, env.opts.encoding);
         
-        if (packageJson) {
-            var packageDocs = new (require('jsdoc/package').Package)(packageJson);
-            packageDocs.files = sourceFiles || [];
-            docs.push(packageDocs);
-        }
+        //The files are ALWAYS useful for the templates to have
+        //If there is no package.json, just create an empty package
+        var packageDocs = new (require('jsdoc/package').Package)(packageJson);
+        packageDocs.files = sourceFiles || [];
+        docs.push(packageDocs);
         
         function indexAll(docs) {
             var lookupTable = {};

--- a/rhino_modules/jsdoc/package.js
+++ b/rhino_modules/jsdoc/package.js
@@ -15,6 +15,8 @@
     @param {string} json - The contents of package.json.
  */
 exports.Package = function(json) {
+    json = json || "{}";
+
     /** The source files associated with this package.
         @type {Array<String>}
      */

--- a/templates/default/publish.js
+++ b/templates/default/publish.js
@@ -185,7 +185,7 @@
 	        namespaces = find({kind: 'namespace'});
 
         var outdir = opts.destination;
-        if (packageInfo) {
+        if (packageInfo && packageInfo.name) {
             outdir += '/' + packageInfo.name + '/' + packageInfo.version + '/';
         }
         fs.mkPath(outdir);


### PR DESCRIPTION
Previously, the list of source files was only added to a package doclet and passed through to the templates if there was a package.json specified.  Now, that doclet is always added.  If there is no package.json, then only the 'files' property of the doclet will be defined.
