### PR TITLE
Allow braces for @extends values (e.g. {Type})

### DIFF
--- a/rhino_modules/jsdoc/tag.js
+++ b/rhino_modules/jsdoc/tag.js
@@ -49,7 +49,7 @@ exports.Tag = function(tagTitle, tagBody, meta) {
         
         if (tagDef.canHaveType) {
         
-            /** The value propertiy represents the result of parsing the tag text. */
+            /** The value property represents the result of parsing the tag text. */
             this.value = {};
             
             var [
@@ -59,7 +59,7 @@ exports.Tag = function(tagTitle, tagBody, meta) {
                 /*?boolean*/ nullable,
                 /*?boolean*/ variable
             ] = jsdoc.tag.type.parse(this.text);
-            
+
             if (typeNames.length) {
                 this.value.type = {
                     names:    typeNames,

--- a/rhino_modules/jsdoc/tag/dictionary/definitions.js
+++ b/rhino_modules/jsdoc/tag/dictionary/definitions.js
@@ -51,6 +51,12 @@ exports.defineTags = function(dictionary) {
     // I add on to that
     dictionary.defineTag('augments', {
         mustHaveValue: true,
+        // Allow augments value to be specified as a normal type, e.g. {Type}
+        onTagText: function(text) {
+            var type = require('jsdoc/tag/type'),
+                [tp, tx] = type.getTagType(text);
+            return tp || text;
+        },
         onTagged: function(doclet, tag) {
             doclet.augment( firstWordOf(tag.value) );
         }

--- a/rhino_modules/jsdoc/tag/type.js
+++ b/rhino_modules/jsdoc/tag/type.js
@@ -19,27 +19,7 @@ exports.parse = function(tagValue) {
 		nullable,
 		variable;
 	
-	// type expressions start with '{'
-	if (tagValue[0] === '{') {
-		count++;
-		
-		// find matching closer '}'
-		for (var i = 1, leni = tagValue.length; i < leni; i++) {
-		    if (tagValue[i] === '\\') { i++; continue; } // backslash escapes the next character
-		    
-			if (tagValue[i] === '{') { count++; }
-			else if (tagValue[i] === '}') { count--; }
-
-			if (count === 0) {
-				type = trim(tagValue.slice(1, i))
-				       .replace(/\\\{/g, '{') // unescape escaped curly braces
-				       .replace(/\\\}/g, '}');
-				text = trim(tagValue.slice(i+1));
-				break;
-			}
-		}
-	}
-
+	[type, text] = getTagType(tagValue);
 	if (type === '') { text = tagValue; }
 	
 	[type, optional] = parseOptional(type);
@@ -104,6 +84,35 @@ function parseTypes(type) {
 	
 	return types;
 }
+
+function getTagType(tagValue) {
+    var type = '',
+        text = '',
+        count = 0;
+
+    // type expressions start with '{'
+    if (tagValue[0] === '{') {
+        count++;
+
+        // find matching closer '}'
+        for (var i = 1, leni = tagValue.length; i < leni; i++) {
+            if (tagValue[i] === '\\') { i++; continue; } // backslash escapes the next character
+
+            if (tagValue[i] === '{') { count++; }
+            else if (tagValue[i] === '}') { count--; }
+
+            if (count === 0) {
+                type = trim(tagValue.slice(1, i))
+                       .replace(/\\\{/g, '{') // unescape escaped curly braces
+                       .replace(/\\\}/g, '}');
+                text = trim(tagValue.slice(i+1));
+                break;
+            }
+        }
+    }
+    return [type, text];
+}
+exports.getTagType = getTagType;
 
 /** @private */
 function trim(text) {

--- a/test/cases/augmentstag.js
+++ b/test/cases/augmentstag.js
@@ -39,7 +39,7 @@ Bar.prototype.method2 = function() {};
 
 /**
  * @constructor
- * @extends Bar
+ * @extends {Bar}
  */
 function Baz() {
     /** Override prop1 */


### PR DESCRIPTION
Fixes#96.  Includes test
