### PR TITLE
Add "short-form" command for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,19 @@ Download a copy of JSDoc 3 from the official Git Hub repository here:
 <https://github.com/jsdoc3/jsdoc>
 
 To test that jsdoc is working, change your working directory to the jsdoc folder
-and run the following command:
+and run the following command on Windows:
 
-	java -cp lib/js.jar org.mozilla.javascript.tools.shell.Main \
-	-modules node_modules -modules rhino_modules -modules . \
-	jsdoc.js -T
-	
-If you are operating on a Mac OSX or *nix platform, you can shorten that command
-to this:
+    jsdoc -T
+
+... or on a Max OSX or *nix platform:
 
     ./jsdoc -T
+
+If you can't get the short-form commands to work, try invoking Java directly:
+
+    java -cp lib/js.jar org.mozilla.javascript.tools.shell.Main \
+    -modules node_modules -modules rhino_modules -modules . \
+    jsdoc.js -T
 
 Usage
 -----
@@ -38,7 +41,7 @@ directory:
 
 For help regarding the supported commandline options use the --help option.
 
-	./jsdoc --help
+    ./jsdoc --help
 
 Generated documentation will appear in the folder specified by the --destination
 option, or in a folder named "out" by default.

--- a/jsdoc.cmd
+++ b/jsdoc.cmd
@@ -1,0 +1,23 @@
+@ECHO OFF
+
+SETLOCAL
+
+REM jsdoc.js expects Unix-style paths without a trailing slash
+SET _BASEPATH=%~dp0
+SET _BASEPATH=%_BASEPATH:\=/%
+SET _BASEPATH=%_BASEPATH:~0,-1%
+
+REM for whatever reason, Rhino requires module paths to be valid URIs
+SET _URLPATH=file:/%_BASEPATH%
+
+:ESCAPE_SPACE
+SET _TRAILING=%_URLPATH:* =%
+CALL SET _URLPATH=%%_URLPATH: %_TRAILING%=%%
+SET _URLPATH=%_URLPATH%%%20%_TRAILING%
+IF NOT "%_URLPATH%"=="%_URLPATH: =%" GOTO ESCAPE_SPACE
+
+java -classpath "%_BASEPATH%/lib/js.jar" org.mozilla.javascript.tools.shell.Main -modules "%_URLPATH%/node_modules" -modules "%_URLPATH%/rhino_modules" -modules "%_URLPATH%" "%_BASEPATH%/jsdoc.js" %* --dirname="%_BASEPATH%/
+
+REM java -classpath "%_BASEPATH%/lib/js.jar" org.mozilla.javascript.tools.debugger.Main -debug -modules "%_URLPATH%/node_modules/" -modules "%_URLPATH%/rhino_modules/" -modules "%_URLPATH%/" "%_BASEPATH%/jsdoc.js" %* --dirname="%_BASEPATH%/
+
+ENDLOCAL


### PR DESCRIPTION
This commit includes a `jsdoc.cmd` file which can be used to execute JSDoc as just e.g. `jsdoc -T` on Windows as well as the supporting changes to `README.md`.

This script passes all tests when run either from the working directory or any other, even across drives.  I have preserved the structure and layout of the existing *nix `jsdoc` command as much as possible, including a commented-out debug version of the call to Java.
