### PR TITLE
Allow absolute template path with -t option

### DIFF
--- a/jsdoc.js
+++ b/jsdoc.js
@@ -113,7 +113,12 @@ function dump() {
 */
 function include(filepath) {
     try {
-        load(__dirname + '/' + filepath);
+        if (filepath.indexOf('/') === 0) {
+            load(filepath);
+        }
+        else {
+            load(__dirname + '/' + filepath);
+        }
     }
     catch (e) {
         console.log('Cannot include "' + __dirname + '/' + filepath + '": '+e);


### PR DESCRIPTION
This allow using a template file that is outside the jsdoc folder. 

This is needed for shipping a publish.js file inside a Drupal module and use it with jsdoc without needing to copy it.
