### PR TITLE
Fix parser.js so it doesn't throw exceptions when parsing itself

### DIFF
--- a/rhino_modules/jsdoc/src/parser.js
+++ b/rhino_modules/jsdoc/src/parser.js
@@ -143,17 +143,11 @@ function pretreat(code) {
         // make starbangstar comments look like real jsdoc comments
         .replace(/\/\*\!\*/g, '/**')
 
-        // make matching comment endings easier
-        .replace(/\*\//g, '»')
-
         // merge adjacent doclets
-        .replace(/»\/\*\*+/g, '@also')
+        .replace(/\*\/\/\*\*+/g, '@also')
         // make lent objectliterals documentable by giving them a dummy name
-        .replace(/(\/\*\*[^»]*?@lends\b[^»]*?»\s*)\{/g, '$1 ____ = {') // like return @lends {
-        .replace(/(\/\*\*[^»]*?@lends\b[^»]*?»)(\s*)return(\s*)\{/g, '$2$3 return $1 ____ = {') // like @lends return {
-
-        // make matching comment endings harder
-        .replace(/»/g, '*/');
+        .replace(/(\/\*\*[^\*\/]*?@lends\b[^\*\/]*?\*\/\s*)\{/g, '$1 ____ = {') // like return @lends {
+        .replace(/(\/\*\*[^\*\/]*?@lends\b[^\*\/]*?\*\/)(\s*)return(\s*)\{/g, '$2$3 return $1 ____ = {'); // like @lends return {
 }
 
 var tkn = { NAMEDFUNCTIONSTATEMENT: -1001 };

--- a/test/specs/jsdoc/src/parser.js
+++ b/test/specs/jsdoc/src/parser.js
@@ -39,6 +39,18 @@ describe("jsdoc/src/parser", function() {
                 parser.on('symbolFound', spy).parse(sourceCode);
                 expect(spy).toHaveBeenCalled();
             });
+            
+            it("should be able to parse its own source file", function() {
+                var fs = require("fs"),
+                    path = require("path"),
+                    parserSrc = "javascript:" + fs.readFileSync( path.join(__dirname,
+                        "rhino_modules", "jsdoc", "src", "parser.js") ),
+                    parse = function() {
+                        parser.parse(parserSrc);
+                    };
+                
+                expect(parse).not.toThrow();
+            });
         });
     });
 });


### PR DESCRIPTION
If you ask parser.js to parse itself, it fails with a gnarly string of syntax errors:

```
js: "rhino_modules/jsdoc/src/parser.js", line 152: syntax error
js:         .replace(/(\/\*\*[^*/]*?@lends\b[^*/]*?*/\s*)\{/g, '$1 ____ = {') // like return @lends {
js: .............................^
js: "rhino_modules/jsdoc/src/parser.js", line 152: illegal character
js:         .replace(/(\/\*\*[^*/]*?@lends\b[^*/]*?*/\s*)\{/g, '$1 ____ = {') // like return @lends {
js: .......................................^
js: "rhino_modules/jsdoc/src/parser.js", line 152: syntax error
js:         .replace(/(\/\*\*[^*/]*?@lends\b[^*/]*?*/\s*)\{/g, '$1 ____ = {') // like return @lends {
js: ..........................................^
js: "rhino_modules/jsdoc/src/parser.js", line 152: illegal character
js:         .replace(/(\/\*\*[^*/]*?@lends\b[^*/]*?*/\s*)\{/g, '$1 ____ = {') // like return @lends {
js: ..................................................^
js: "rhino_modules/jsdoc/src/parser.js", line 152: syntax error
js:         .replace(/(\/\*\*[^*/]*?@lends\b[^*/]*?*/\s*)\{/g, '$1 ____ = {') // like return @lends {
js: ....................................................^
js: "rhino_modules/jsdoc/src/parser.js", line 152: illegal character
js:         .replace(/(\/\*\*[^*/]*?@lends\b[^*/]*?*/\s*)\{/g, '$1 ____ = {') // like return @lends {
js: ......................................................^
js: "rhino_modules/jsdoc/src/parser.js", line 152: missing ; before statement
js:         .replace(/(\/\*\*[^*/]*?@lends\b[^*/]*?*/\s*)\{/g, '$1 ____ = {') // like return @lends {
js: ........................................................................................^
js: "rhino_modules/jsdoc/src/parser.js", line 153: illegal character
js:         .replace(/(\/\*\*[^*/]*?@lends\b[^*/]*?*/)(\s*)return(\s*)\{/g, '$2$3 return $1 ____ = {') // like @lends return {
js: ....................................................^
js: "rhino_modules/jsdoc/src/parser.js", line 153: missing ) after argument list
js:         .replace(/(\/\*\*[^*/]*?@lends\b[^*/]*?*/)(\s*)return(\s*)\{/g, '$2$3 return $1 ____ = {') // like @lends return {
js: .....................................................^
js: "rhino_modules/jsdoc/src/parser.js", line 153: illegal character
js:         .replace(/(\/\*\*[^*/]*?@lends\b[^*/]*?*/)(\s*)return(\s*)\{/g, '$2$3 return $1 ____ = {') // like @lends return {
js: ...............................................................^
js: "rhino_modules/jsdoc/src/parser.js", line 153: syntax error
js:         .replace(/(\/\*\*[^*/]*?@lends\b[^*/]*?*/)(\s*)return(\s*)\{/g, '$2$3 return $1 ____ = {') // like @lends return {
js: .................................................................^
js: "rhino_modules/jsdoc/src/parser.js", line 153: illegal character
js:         .replace(/(\/\*\*[^*/]*?@lends\b[^*/]*?*/)(\s*)return(\s*)\{/g, '$2$3 return $1 ____ = {') // like @lends return {
js: ...................................................................^
js: "rhino_modules/jsdoc/src/parser.js", line 153: missing ; before statement
js:         .replace(/(\/\*\*[^*/]*?@lends\b[^*/]*?*/)(\s*)return(\s*)\{/g, '$2$3 return $1 ____ = {') // like @lends return {
js: ...........................................................................................................^
js: "rhino_modules/jsdoc/src/parser.js", line 156: unterminated string literal
js:         .replace(/*//g, '*/');
js: .............................^
js: "rhino_modules/jsdoc/src/parser.js", line 157: missing ) after argument list
js: }
js: ^
js: "rhino_modules/jsdoc/src/parser.js", line 639: missing } in compound statement
js: */
js: .^
js: "rhino_modules/jsdoc/src/parser.js", line 639: missing } in compound statement
js: */
js: .^
js: "rhino_modules/jsdoc/src/parser.js", line 639: missing } after function body
js: */
js: .^
org.mozilla.javascript.EvaluatorException: Compilation produced 18 syntax errors. (rhino_modules/jsdoc/src/parser.js#1)
    at org.mozilla.javascript.tools.ToolErrorReporter.runtimeError(ToolErrorReporter.java:144)
    at org.mozilla.javascript.Parser.parse(Parser.java:596)
    at org.mozilla.javascript.Parser.parse(Parser.java:505)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
    at java.lang.reflect.Method.invoke(Method.java:597)
    at org.mozilla.javascript.MemberBox.invoke(MemberBox.java:161)
    at org.mozilla.javascript.NativeJavaMethod.call(NativeJavaMethod.java:247)
    at org.mozilla.javascript.optimizer.OptRuntime.callN(OptRuntime.java:86)
    at org.mozilla.javascript.gen.file__Users_jeffw_dev_jsdoc_rhino_modules_jsdoc_src_parser_js_7._c_anonymous_8(Unknown Source)
    at org.mozilla.javascript.gen.file__Users_jeffw_dev_jsdoc_rhino_modules_jsdoc_src_parser_js_7.call(Unknown Source)
    at org.mozilla.javascript.optimizer.OptRuntime.call2(OptRuntime.java:76)
    at org.mozilla.javascript.gen.file__Users_jeffw_dev_jsdoc_rhino_modules_jsdoc_src_parser_js_7._c_anonymous_2(Unknown Source)
    at org.mozilla.javascript.gen.file__Users_jeffw_dev_jsdoc_rhino_modules_jsdoc_src_parser_js_7.call(Unknown Source)
    at org.mozilla.javascript.optimizer.OptRuntime.call2(OptRuntime.java:76)
    at org.mozilla.javascript.gen._Users_jeffw_dev_jsdoc_jsdoc_js_1._c_main_7(Unknown Source)
    at org.mozilla.javascript.gen._Users_jeffw_dev_jsdoc_jsdoc_js_1.call(Unknown Source)
    at org.mozilla.javascript.optimizer.OptRuntime.callName0(OptRuntime.java:108)
    at org.mozilla.javascript.gen._Users_jeffw_dev_jsdoc_jsdoc_js_1._c_script_0(Unknown Source)
    at org.mozilla.javascript.gen._Users_jeffw_dev_jsdoc_jsdoc_js_1.call(Unknown Source)
    at org.mozilla.javascript.ContextFactory.doTopCall(ContextFactory.java:426)
    at org.mozilla.javascript.ScriptRuntime.doTopCall(ScriptRuntime.java:3178)
    at org.mozilla.javascript.gen._Users_jeffw_dev_jsdoc_jsdoc_js_1.call(Unknown Source)
    at org.mozilla.javascript.gen._Users_jeffw_dev_jsdoc_jsdoc_js_1.exec(Unknown Source)
    at org.mozilla.javascript.tools.shell.Main.evaluateScript(Main.java:654)
    at org.mozilla.javascript.tools.shell.Main.processFileSecure(Main.java:552)
    at org.mozilla.javascript.tools.shell.Main.processFile(Main.java:507)
    at org.mozilla.javascript.tools.shell.Main.processSource(Main.java:499)
    at org.mozilla.javascript.tools.shell.Main.processFiles(Main.java:215)
    at org.mozilla.javascript.tools.shell.Main$IProxy.run(Main.java:134)
    at org.mozilla.javascript.Context.call(Context.java:521)
    at org.mozilla.javascript.ContextFactory.call(ContextFactory.java:535)
    at org.mozilla.javascript.tools.shell.Main.exec(Main.java:198)
    at org.mozilla.javascript.tools.shell.Main.main(Main.java:174)
```

This happens because `pretreat()` attempts to simplify some regexps by replacing each `*/` with a sentinel, then vice-versa. Unfortunately, this fouls up the regexps in `pretreat()`, making them syntactically invalid.

The changes get rid of the sentinels and add a test to verify that parser.js can parse itself.

_Note_: If you pull #132 before this request, I'll need to update this request to use `env.dirname` instead of `__dirname`.
