### PR TITLE
--strict option doesn't work correctly

### DIFF
--- a/rhino_modules/jsdoc/opts/parser.js
+++ b/rhino_modules/jsdoc/opts/parser.js
@@ -12,8 +12,7 @@ var common = {
 var argParser = new common.args.ArgParser(),
 	ourOptions,
 	defaults = {
-		destination: './out/',
-		strict: true
+		destination: './out/'
 	};
 
 argParser.addOption('t', 'template',    true,  'The name of the template to use. Default: the "default" template');
@@ -23,7 +22,7 @@ argParser.addOption('T', 'test',        false, 'Run all tests and quit.');
 argParser.addOption('d', 'destination', true,  'The path to the output folder. Use "console" to dump data to the console. Default: console');
 argParser.addOption('p', 'private',     false, 'Display symbols marked with the @private tag. Default: false.');
 argParser.addOption('r', 'recurse',     false, 'Recurse into subdirectories when scanning for source code files.');
-argParser.addOption('s', 'strict',      false, 'Exit immediately if a doclet is incomplete or contains errors. Default: true');
+argParser.addOption('l', 'lenient',     false, 'Continue to generate output if a doclet is incomplete or contains errors. Default: false.');
 argParser.addOption('h', 'help',        false, 'Print this message and quit.');
 argParser.addOption('X', 'explain',     false, 'Dump all found doclet internals to console and quit.');
 argParser.addOption('q', 'query',       true,  'Provide a querystring to define custom variable names/values to add to the options hash.');

--- a/rhino_modules/jsdoc/tag.js
+++ b/rhino_modules/jsdoc/tag.js
@@ -86,15 +86,15 @@ exports.Tag = function(tagTitle, tagBody, meta) {
         }
     }
     
-    // validate the tag. for strict validation, throw an exception; otherwise, log a warning.
+    // validate the tag. in lenient mode, log a warning; otherwise, throw an exception.
     try {
         jsdoc.tag.validator.validate(this, meta);
     }
     catch (e) {
-        if (env.opts.strict) {
-            throw e;
-        } else {
+        if (env.opts.lenient) {
             console.log(e);
+        } else {
+            throw e;
         }
     }
 }

--- a/test/specs/jsdoc/tag.js
+++ b/test/specs/jsdoc/tag.js
@@ -8,31 +8,29 @@ describe("jsdoc/tag", function() {
         return tag;
     }
 
-    it("has strict validation enabled by default", function() {
+    it("is strict, not lenient, by default", function() {
         expect(badTag).toThrow();
     });
 
-    it("throws an exception for bad tags if strict validation is enabled", function() {
-        var strict = !!env.opts.strict;
+    it("throws an exception for bad tags if the lenient option is not enabled", function() {
+        var lenient = !!env.opts.lenient;
         
-        env.opts.strict = true;
-        
+        env.opts.lenient = false;
         expect(badTag).toThrow();
         
-        env.opts.strict = strict;
+        env.opts.lenient = lenient;
     });
     
-    it("doesn't throw an exception for bad tags if strict validation is disabled", function() {
+    it("doesn't throw an exception for bad tags if the lenient option is enabled", function() {
         /*jshint evil: true */
-        var strict = !!env.opts.strict,
-            log = new Function(console.log);
-        
+        var lenient = !!env.opts.lenient,
+            log = eval(console.log);
         console.log = function() {};
-        env.opts.strict = false;
         
+        env.opts.lenient = true;
         expect(badTag).not.toThrow();
         
-        env.opts.strict = strict;
+        env.opts.lenient = lenient;
         console.log = log;
     });
 });


### PR DESCRIPTION
It turns out that my fix for #134 doesn't work correctly. For a couple of reasons*, the `--strict` command-line option is broken. Mea culpa.

This pull request replaces the broken `--strict` command-line option with a working `--lenient` command-line option. The `--lenient` option is disabled by default, so JSDoc's default behavior hasn't changed from #134: If a doclet can't be validated, JSDoc exits.

(I also fixed an issue in the test: `console.log` now actually works after the test runs. How embarrassing.)

I didn't want to change the name of the command-line option, but when `common/args` sees `--foo false`, it treats `false` as a string rather than a boolean. I decided I'd rather work within the limitations of `common/args` than write code like `if (foo === false || foo === "false")`. I can redo this change if people like `--strict false` better than `--lenient`.

Again, sorry I didn't get this right the first time!

\* Reason 1: Because the call to `addOption()` passed `false` in the third argument, the option didn't accept a value. Reason 2: Even if you dealt with reason 1, the code in `tag.js` wouldn't have worked, because `common/args` treats all values as strings.
