### PR TITLE
Make JSDoc JSHint-clean (part 3)

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -4,7 +4,7 @@
   "eqeqeq":       false,
   "forin":        true,
   "immed":        true,
-  "latedef":      false,
+  "latedef":      true,
   "newcap":       true,
   "noarg":        true,
   "noempty":      false,

--- a/jsdoc.js
+++ b/jsdoc.js
@@ -91,29 +91,6 @@ include.resolve = function(filepath) {
     return env.dirname + '/' + filepath;
 }
 
-
-/**
-    Data that must be shared across the entire application.
-    @namespace
-*/
-app = {
-    jsdoc: {
-        scanner: new (require('jsdoc/src/scanner').Scanner)(),
-        parser: new (require('jsdoc/src/parser').Parser)(),
-        name: require('jsdoc/name')
-    }
-}
-
-try { main(); }
-catch(e) {
-     if (e.rhinoException != null) {
-         e.rhinoException.printStackTrace();
-     } else {
-        throw e;
-    }
-}
-finally { env.run.finish = new Date(); }
-
 /** Print string/s out to the console.
     @param {string} ... String/s to print out to console.
  */
@@ -182,6 +159,19 @@ function indexAll(docs) {
         lookupTable[doc.longname].push(doc);
     });
     docs.index = lookupTable;
+}
+
+
+/**
+    Data that must be shared across the entire application.
+    @namespace
+*/
+app = {
+    jsdoc: {
+        scanner: new (require('jsdoc/src/scanner').Scanner)(),
+        parser: new (require('jsdoc/src/parser').Parser)(),
+        name: require('jsdoc/name')
+    }
 }
 
 
@@ -324,3 +314,13 @@ function main() {
         }
     }
 }
+
+try { main(); }
+catch(e) {
+     if (e.rhinoException != null) {
+         e.rhinoException.printStackTrace();
+     } else {
+        throw e;
+    }
+}
+finally { env.run.finish = new Date(); }

--- a/rhino_modules/fs.js
+++ b/rhino_modules/fs.js
@@ -5,6 +5,19 @@ exports.readFileSync = function(filename, encoding) {
     return readFile(filename, encoding);
 };
 
+var stat = exports.stat = exports.statSync = function(path, encoding) {
+    var f = new java.io.File(path);
+    return {
+        isFile: function() {
+            return f.isFile();
+        },
+        isDirectory: function() {
+            return f.isDirectory();
+        }
+    };
+
+};
+
 var readdirSync = exports.readdirSync = function(path) {
     var dir,
         files;
@@ -64,28 +77,17 @@ var ls = exports.ls = function(dir, recurse, _allFiles, _path) {
     return _allFiles;
 };
 
-var stat = exports.stat = exports.statSync = function(path, encoding) {
+var toDir = exports.toDir = function(path) {
     var f = new java.io.File(path);
-    return {
-        isFile: function() {
-            return f.isFile();
-        },
-        isDirectory: function() {
-            return f.isDirectory();
-        }
-    };
 
-};
-
-exports.mkPath = function(/**Array*/ path) {
-    if (path.constructor != Array){path = path.split(/[\\\/]/);}
-    var make = "";
-    for (var i = 0, l = path.length; i < l; i++) {
-        make += path[i] + '/';
-        if (! exists(make)) {
-            makeDir(make);
-        }
+    if (f.isDirectory()){
+       return path;
     }
+
+    var parts = path.split(/[\\\/]/);
+    parts.pop();
+
+    return parts.join('/');
 };
 
 function makeDir(/**string*/ path) {
@@ -108,17 +110,20 @@ function exists(path) {
     return true;
 }
 
-var toDir = exports.toDir = function(path) {
-    var f = new java.io.File(path);
-
-    if (f.isDirectory()){
-       return path;
+exports.mkPath = function(/**Array*/ path) {
+    if (path.constructor != Array){path = path.split(/[\\\/]/);}
+    var make = "";
+    for (var i = 0, l = path.length; i < l; i++) {
+        make += path[i] + '/';
+        if (! exists(make)) {
+            makeDir(make);
+        }
     }
+};
 
+var toFile = exports.toFile = function(path) {
     var parts = path.split(/[\\\/]/);
-    parts.pop();
-
-    return parts.join('/');
+    return parts.pop();
 };
 
 exports.copyFile = function(inFile, outDir, fileName) {
@@ -137,11 +142,6 @@ exports.copyFile = function(inFile, outDir, fileName) {
     }
     bos.close();
     bis.close();
-};
-
-var toFile = exports.toFile = function(path) {
-    var parts = path.split(/[\\\/]/);
-    return parts.pop();
 };
 
 exports.writeFileSync = function(filename, data, encoding) {

--- a/rhino_modules/jsdoc/config.js
+++ b/rhino_modules/jsdoc/config.js
@@ -21,8 +21,6 @@ const defaults = {
     "jsVersion": 180
 };
 
-module.exports = Config;
-
 /**
     @class
     @classdesc Represents a JSDoc application configuration.
@@ -33,6 +31,8 @@ function Config(json) {
     
     this._config = util.mergeRecurse(defaults, json);
 }
+
+module.exports = Config;
 
 /**
     Get the merged configuration values.

--- a/rhino_modules/jsdoc/readme.js
+++ b/rhino_modules/jsdoc/readme.js
@@ -12,34 +12,8 @@
     @author Ben Blank <ben.blank@gmail.com>
  */
 
-module.exports = ReadMe;
-
 var fs = require('fs'),
     conf = env.conf.markdown;
-
-/**
-    @class
-    @classdesc Represents a README file.
-    @param {string} path - The filepath to the README.
- */
-function ReadMe(path) {
-    var content = fs.readFileSync(path),
-        parse;
-    
-    // determine which parser should be used based on configuration options, if any
-    if (conf && conf.parser) {
-        parse = getParser(conf.parser, conf);
-    } else if (conf && conf.githubRepoOwner && conf.githubRepoName) {
-        // use GitHub-friendly parser if GitHub-specific options are present
-        parse = getParser('gfm', conf);
-    } else {
-        // evilstreak is the default parser
-        parse = getParser('evilstreak', conf);
-    }
-    
-    this.html = parse(content);
-    
-}
 
 function getParser(parser, conf) {
     conf = conf || {};
@@ -66,3 +40,28 @@ function getParser(parser, conf) {
     }
 }
 
+/**
+    @class
+    @classdesc Represents a README file.
+    @param {string} path - The filepath to the README.
+ */
+function ReadMe(path) {
+    var content = fs.readFileSync(path),
+        parse;
+    
+    // determine which parser should be used based on configuration options, if any
+    if (conf && conf.parser) {
+        parse = getParser(conf.parser, conf);
+    } else if (conf && conf.githubRepoOwner && conf.githubRepoName) {
+        // use GitHub-friendly parser if GitHub-specific options are present
+        parse = getParser('gfm', conf);
+    } else {
+        // evilstreak is the default parser
+        parse = getParser('evilstreak', conf);
+    }
+    
+    this.html = parse(content);
+    
+}
+
+module.exports = ReadMe;

--- a/rhino_modules/jsdoc/src/handlers.js
+++ b/rhino_modules/jsdoc/src/handlers.js
@@ -39,7 +39,8 @@ exports.attachTo = function(parser) {
     });
 
     function newSymbolDoclet(docletSrc, e) {
-        var newDoclet = new jsdoc.doclet.Doclet(docletSrc, e);
+        var memberofName = null,
+            newDoclet = new jsdoc.doclet.Doclet(docletSrc, e);
 
         // an undocumented symbol right after a virtual comment? rhino mistakenly connected the two
         if (newDoclet.name) { // there was a @name in comment
@@ -64,8 +65,7 @@ exports.attachTo = function(parser) {
         else if (e.code && e.code.name) { // we need to get the symbol name from code
             newDoclet.addTag('name', e.code.name);
             if (!newDoclet.memberof && e.astnode) {
-                var memberofName = null,
-                    basename = null,
+                var basename = null,
                     scope = '';
                 if ( /^((module.)?exports|this)(\.|$)/.test(newDoclet.name) ) {
                     var nameStartsWith = RegExp.$1;

--- a/rhino_modules/jsdoc/tag.js
+++ b/rhino_modules/jsdoc/tag.js
@@ -22,6 +22,45 @@ var jsdoc = {
     }
 };
 
+function trim(text, newlines) {
+    if (!text) { return ''; }
+    
+    if (newlines) {
+        return text.replace(/^[\n\r\f]+|[\n\r\f]+$/g, '');
+    }
+    else {
+        return text.replace(/^\s+|\s+$/g, '');
+    }
+}
+
+/**
+    Parse the parameter name and parameter desc from the tag text.
+    @inner
+    @method parseParamText
+    @memberof module:jsdoc/tag
+    @param {string} tagText
+    @returns {Array.<string, string, boolean, boolean>} [pname, pdesc, poptional, pdefault].
+ */
+function parseParamText(tagText) {
+    var pname, pdesc, poptional, pdefault;
+
+    // like: pname, pname pdesc, or name - pdesc
+    tagText.match(/^(\[[^\]]+\]|\S+)((?:\s*\-\s*|\s+)(\S[\s\S]*))?$/);
+    pname = RegExp.$1;
+    pdesc = RegExp.$3;
+
+    if ( /^\[\s*(.+?)\s*\]$/.test(pname) ) {
+        pname = RegExp.$1;
+        poptional = true;
+        
+        if ( /^(.+?)\s*=\s*(.+)$/.test(pname) ) {
+            pname = RegExp.$1;
+            pdefault = RegExp.$2;
+        }
+    }
+    return { name: pname, desc: pdesc, optional: poptional, default: pdefault };
+}
+
 /**
     Constructs a new tag object. Calls the tag validator.
     @class
@@ -98,43 +137,4 @@ exports.Tag = function(tagTitle, tagBody, meta) {
             throw e;
         }
     }
-}
-
-function trim(text, newlines) {
-    if (!text) { return ''; }
-    
-    if (newlines) {
-        return text.replace(/^[\n\r\f]+|[\n\r\f]+$/g, '');
-    }
-    else {
-        return text.replace(/^\s+|\s+$/g, '');
-    }
-}
-
-/**
-    Parse the parameter name and parameter desc from the tag text.
-    @inner
-    @method parseParamText
-    @memberof module:jsdoc/tag
-    @param {string} tagText
-    @returns {Array.<string, string, boolean, boolean>} [pname, pdesc, poptional, pdefault].
- */
-function parseParamText(tagText) {
-    var pname, pdesc, poptional, pdefault;
-
-    // like: pname, pname pdesc, or name - pdesc
-    tagText.match(/^(\[[^\]]+\]|\S+)((?:\s*\-\s*|\s+)(\S[\s\S]*))?$/);
-    pname = RegExp.$1;
-    pdesc = RegExp.$3;
-
-    if ( /^\[\s*(.+?)\s*\]$/.test(pname) ) {
-        pname = RegExp.$1;
-        poptional = true;
-        
-        if ( /^(.+?)\s*=\s*(.+)$/.test(pname) ) {
-            pname = RegExp.$1;
-            pdefault = RegExp.$2;
-        }
-    }
-    return { name: pname, desc: pdesc, optional: poptional, default: pdefault };
 }

--- a/rhino_modules/jsdoc/tag/dictionary.js
+++ b/rhino_modules/jsdoc/tag/dictionary.js
@@ -7,6 +7,7 @@
 var _synonyms = {},
     _definitions = {},
     _namespaces = [],
+    dictionary,
     hasOwnProp = Object.prototype.hasOwnProperty;
 
 /** @private */
@@ -29,7 +30,7 @@ TagDefinition.prototype.synonym = function(synonymName) {
 }
 
 /** @exports jsdoc/tag/dictionary */
-var dictionary = {
+dictionary = {
     /** @function */
     defineTag: function(title, opts) {
         _definitions[title] = new TagDefinition(title, opts);

--- a/rhino_modules/jsdoc/tag/dictionary/definitions.js
+++ b/rhino_modules/jsdoc/tag/dictionary/definitions.js
@@ -7,6 +7,91 @@
 	@license Apache License 2.0 - See file 'LICENSE.md' in this project.
  */
 
+/** @private */
+function setDocletKindToTitle(doclet, tag) {
+    doclet.addTag( 'kind', tag.title );
+}
+
+function setDocletScopeToTitle(doclet, tag) {
+    doclet.addTag( 'scope', tag.title );
+}
+
+function setDocletNameToValue(doclet, tag) {
+    if (tag.value && tag.value.description) { // as in a long tag
+        doclet.addTag( 'name', tag.value.description);
+    }
+    else if (tag.text) { // or a short tag
+        doclet.addTag('name', tag.text);
+    }
+}
+
+function setDocletDescriptionToValue(doclet, tag) {
+    if (tag.value) {
+        doclet.addTag( 'description', tag.value );
+    }
+}
+
+function setNameToFile(doclet, tag) {
+    if (doclet.meta.filename) {
+        var name = 'file:';
+        if (doclet.meta.path) { name += doclet.meta.path + java.lang.System.getProperty("file.separator"); }
+        doclet.addTag( 'name', name + doclet.meta.filename );
+    }
+}
+
+function setDocletMemberof(doclet, tag) {
+    if (tag.value && tag.value !== '<global>') {
+        doclet.setMemberof(tag.value);
+    }
+}
+
+function applyNamespace(docletOrNs, tag) {
+    if (typeof docletOrNs === 'string') { // ns
+        tag.value = app.jsdoc.name.applyNamespace(tag.value, docletOrNs);
+    }
+    else { // doclet
+        if (!docletOrNs.name) {
+            return; // error?
+        }
+        
+        //doclet.displayname = doclet.name;
+        docletOrNs.longname = app.jsdoc.name.applyNamespace(docletOrNs.name, tag.title);
+    }
+}
+
+function setDocletNameToFilename(doclet, tag) {
+    var name = (doclet.meta.path ? (doclet.meta.path + java.lang.System.getProperty("file.separator")) : "") + doclet.meta.filename;
+    name = name.replace(/\.js$/i, '');
+    
+    for (var i = 0, len = env.opts._.length; i < len; i++) {
+        if (name.indexOf(env.opts._[i]) === 0) {
+            name = name.replace(env.opts._[0], '');
+            break
+        }
+    }
+    doclet.name = name;
+}
+
+function parseBorrows(doclet, tag) {
+    var m = /^(\S+)(?:\s+as\s+(\S+))?$/.exec(tag.text);
+    if (m) {
+        if (m[1] && m[2]) {
+            return { target: m[1], source: m[2] };
+        }
+        else if (m[1]) {
+            return { target: m[1] };
+        }
+    } else {
+        return {};
+    }
+}
+
+function firstWordOf(string) {
+    var m = /^(\S+)/.exec(string);
+    if (m) { return m[1]; }
+    else { return ''; }
+}
+
 /** Populate the given dictionary with all known JSDoc tag definitions.
     @param {module:jsdoc/tag/dictionary} dictionary
 */
@@ -559,89 +644,4 @@ exports.defineTags = function(dictionary) {
             doclet.version = tag.value;
         }
     });
-}
-
-/** @private */
-function setDocletKindToTitle(doclet, tag) {
-    doclet.addTag( 'kind', tag.title );
-}
-
-function setDocletScopeToTitle(doclet, tag) {
-    doclet.addTag( 'scope', tag.title );
-}
-
-function setDocletNameToValue(doclet, tag) {
-    if (tag.value && tag.value.description) { // as in a long tag
-        doclet.addTag( 'name', tag.value.description);
-    }
-    else if (tag.text) { // or a short tag
-        doclet.addTag('name', tag.text);
-    }
-}
-
-function setDocletDescriptionToValue(doclet, tag) {
-    if (tag.value) {
-        doclet.addTag( 'description', tag.value );
-    }
-}
-
-function setNameToFile(doclet, tag) {
-    if (doclet.meta.filename) {
-        var name = 'file:';
-        if (doclet.meta.path) { name += doclet.meta.path + java.lang.System.getProperty("file.separator"); }
-        doclet.addTag( 'name', name + doclet.meta.filename );
-    }
-}
-
-function setDocletMemberof(doclet, tag) {
-    if (tag.value && tag.value !== '<global>') {
-        doclet.setMemberof(tag.value);
-    }
-}
-
-function applyNamespace(docletOrNs, tag) {
-    if (typeof docletOrNs === 'string') { // ns
-        tag.value = app.jsdoc.name.applyNamespace(tag.value, docletOrNs);
-    }
-    else { // doclet
-        if (!docletOrNs.name) {
-            return; // error?
-        }
-        
-        //doclet.displayname = doclet.name;
-        docletOrNs.longname = app.jsdoc.name.applyNamespace(docletOrNs.name, tag.title);
-    }
-}
-
-function setDocletNameToFilename(doclet, tag) {
-    var name = (doclet.meta.path ? (doclet.meta.path + java.lang.System.getProperty("file.separator")) : "") + doclet.meta.filename;
-    name = name.replace(/\.js$/i, '');
-    
-    for (var i = 0, len = env.opts._.length; i < len; i++) {
-        if (name.indexOf(env.opts._[i]) === 0) {
-            name = name.replace(env.opts._[0], '');
-            break
-        }
-    }
-    doclet.name = name;
-}
-
-function parseBorrows(doclet, tag) {
-    var m = /^(\S+)(?:\s+as\s+(\S+))?$/.exec(tag.text);
-    if (m) {
-        if (m[1] && m[2]) {
-            return { target: m[1], source: m[2] };
-        }
-        else if (m[1]) {
-            return { target: m[1] };
-        }
-    } else {
-        return {};
-    }
-}
-
-function firstWordOf(string) {
-    var m = /^(\S+)/.exec(string);
-    if (m) { return m[1]; }
-    else { return ''; }
 }

--- a/rhino_modules/jsdoc/tag/type.js
+++ b/rhino_modules/jsdoc/tag/type.js
@@ -6,6 +6,95 @@
  */
 
 
+function parseOptional(type) {
+	var optional = null;
+
+	// {sometype=} means optional
+	if ( /(.+)=$/.test(type) ) {
+		type = RegExp.$1;
+		optional = true;
+	}
+
+	return { type: type, optional: optional };
+}
+
+function parseNullable(type) {
+	var nullable = null;
+
+	// {?sometype} means nullable, {!sometype} means not-nullable
+	if ( /^([\?\!])(.+)$/.test(type) ) {
+		type = RegExp.$2;
+		nullable = (RegExp.$1 === '?')? true : false;
+	}
+
+	return { type: type, nullable: nullable };
+}
+
+function parseVariable(type) {
+	var variable = null;
+
+	// {...sometype} means variable number of that type
+	if ( /^(\.\.\.)(.+)$/.test(type) ) {
+		type = RegExp.$2;
+		variable = true;
+	}
+
+	return { type: type, variable: variable };
+}
+
+function parseTypes(type) {
+	var types = [];
+
+	if ( type.indexOf('|') !== -1 ) {
+		// remove optional parens, like: { ( string | number ) }
+		// see: http://code.google.com/closure/compiler/docs/js-for-compiler.html#types
+		if ( /^\s*\(\s*(.+)\s*\)\s*$/.test(type) ) {
+			type = RegExp.$1;
+		}
+		types = type.split(/\s*\|\s*/g);
+	}
+	else if (type) {
+		types = [type];
+	}
+
+	return types;
+}
+
+/** @private */
+function trim(text) {
+	return text.trim();
+}
+
+function getTagType(tagValue) {
+ var type = '',
+     text = '',
+     count = 0;
+
+ // type expressions start with '{'
+ if (tagValue[0] === '{') {
+     count++;
+
+     // find matching closer '}'
+     for (var i = 1, leni = tagValue.length; i < leni; i++) {
+         if (tagValue[i] === '\\') { i++; continue; } // backslash escapes the next character
+
+         if (tagValue[i] === '{') { count++; }
+         else if (tagValue[i] === '}') { count--; }
+
+         if (count === 0) {
+             type = trim(tagValue.slice(1, i))
+                    .replace(/\\\{/g, '{') // unescape escaped curly braces
+                    .replace(/\\\}/g, '}');
+             text = trim(tagValue.slice(i+1));
+             break;
+         }
+     }
+ }
+ return { type: type, text: text };
+}
+exports.getTagType = getTagType;
+
+
 /**
 	@param {string} tagValue
 	@returns {object} Hash with type, text, optional, nullable, and variable properties
@@ -41,92 +130,4 @@ exports.parse = function(tagValue) {
 	    nullable: nullable.nullable,
 	    variable: variable.variable
 	};
-}
-
-function parseOptional(type) {
-	var optional = null;
-	
-	// {sometype=} means optional
-	if ( /(.+)=$/.test(type) ) {
-		type = RegExp.$1;
-		optional = true;
-	}
-	
-	return { type: type, optional: optional };
-}
-
-function parseNullable(type) {
-	var nullable = null;
-	
-	// {?sometype} means nullable, {!sometype} means not-nullable
-	if ( /^([\?\!])(.+)$/.test(type) ) {
-		type = RegExp.$2;
-		nullable = (RegExp.$1 === '?')? true : false;
-	}
-	
-	return { type: type, nullable: nullable };
-}
-
-function parseVariable(type) {
-	var variable = null;
-	
-	// {...sometype} means variable number of that type
-	if ( /^(\.\.\.)(.+)$/.test(type) ) {
-		type = RegExp.$2;
-		variable = true;
-	}
-	
-	return { type: type, variable: variable };
-}
-
-function parseTypes(type) {
-	var types = [];
-	
-	if ( type.indexOf('|') !== -1 ) {
-		// remove optional parens, like: { ( string | number ) }
-		// see: http://code.google.com/closure/compiler/docs/js-for-compiler.html#types
-		if ( /^\s*\(\s*(.+)\s*\)\s*$/.test(type) ) {
-			type = RegExp.$1;
-		}
-		types = type.split(/\s*\|\s*/g);
-	}
-	else if (type) {
-		types = [type];
-	}
-	
-	return types;
-}
-
-function getTagType(tagValue) {
-    var type = '',
-        text = '',
-        count = 0;
-
-    // type expressions start with '{'
-    if (tagValue[0] === '{') {
-        count++;
-
-        // find matching closer '}'
-        for (var i = 1, leni = tagValue.length; i < leni; i++) {
-            if (tagValue[i] === '\\') { i++; continue; } // backslash escapes the next character
-
-            if (tagValue[i] === '{') { count++; }
-            else if (tagValue[i] === '}') { count--; }
-
-            if (count === 0) {
-                type = trim(tagValue.slice(1, i))
-                       .replace(/\\\{/g, '{') // unescape escaped curly braces
-                       .replace(/\\\}/g, '}');
-                text = trim(tagValue.slice(i+1));
-                break;
-            }
-        }
-    }
-    return { type: type, text: text };
-}
-exports.getTagType = getTagType;
-
-/** @private */
-function trim(text) {
-	return text.trim();
 }

--- a/rhino_modules/jsdoc/tag/validator.js
+++ b/rhino_modules/jsdoc/tag/validator.js
@@ -10,6 +10,24 @@
 
 var dictionary = require('jsdoc/tag/dictionary');
 
+function UnknownTagError(tagName, meta) {
+    this.name = 'UnknownTagError';
+    this.message = 'The @' + tagName + ' tag is not a known tag. File: ' + meta.filename + ', Line: ' + meta.lineno + '\n' + meta.comment;
+}
+UnknownTagError.prototype = Error.prototype;
+
+function TagValueRequiredError(tagName, meta) {
+    this.name = 'TagValueRequiredError';
+    this.message = 'The @' + tagName + ' tag requires a value. File: ' + meta.filename + ', Line: ' + meta.lineno + '\n' + meta.comment;
+}
+TagValueRequiredError.prototype = Error.prototype;
+
+function TagValueNotPermittedError(tagName, meta) {
+    this.name = 'TagValueNotPermittedError';
+    this.message = 'The @' + tagName + ' tag does not permit a value. File: ' + meta.filename + ', Line: ' + meta.lineno + '\n' + meta.comment;
+}
+TagValueNotPermittedError.prototype = Error.prototype;
+
 /**
     Validate the given tag.
  */
@@ -31,22 +49,3 @@ exports.validate = function(tag, meta) {
         }
     }
 }
-
-function UnknownTagError(tagName, meta) {
-    this.name = 'UnknownTagError';
-    this.message = 'The @' + tagName + ' tag is not a known tag. File: ' + meta.filename + ', Line: ' + meta.lineno + '\n' + meta.comment;
-}
-UnknownTagError.prototype = Error.prototype;
-
-function TagValueRequiredError(tagName, meta) {
-    this.name = 'TagValueRequiredError';
-    this.message = 'The @' + tagName + ' tag requires a value. File: ' + meta.filename + ', Line: ' + meta.lineno + '\n' + meta.comment;
-}
-TagValueRequiredError.prototype = Error.prototype;
-
-function TagValueNotPermittedError(tagName, meta) {
-    this.name = 'TagValueNotPermittedError';
-    this.message = 'The @' + tagName + ' tag does not permit a value. File: ' + meta.filename + ', Line: ' + meta.lineno + '\n' + meta.comment;
-}
-TagValueNotPermittedError.prototype = Error.prototype;
-

--- a/rhino_modules/jsdoc/util/dumper.js
+++ b/rhino_modules/jsdoc/util/dumper.js
@@ -5,18 +5,6 @@
 	@license Apache License 2.0 - See file 'LICENSE.md' in this project.
  */
 
-/**
-    @param {any} object
- */
-exports.dump = function(object) {
-    indentBy = 0;
-    output = '';
-    
-    walk(object);
-    outdent(false);
-    return output;
-}
-
 const INDENTATION = '    '; // 4 spaces
 var indentBy,
     output;
@@ -60,6 +48,45 @@ seen.has = function(object) {
         if (seen[i] === object) { return true; }
     }
     return false;
+}
+
+function stringify(o) {
+    return JSON.stringify(o);
+}
+
+function getValue(o) { // see: https://developer.mozilla.org/en/JavaScript/Reference/Operators/Special/typeof
+    if (o === null) { return 'null'; }
+    if ( /^(string|boolean|number|undefined)$/.test(typeof o) ) {
+        return ''+stringify(o);
+    }
+}
+
+function isUnwalkable(o) { // some objects are unwalkable, like Java native objects
+    return (typeof o === 'object' && typeof o.constructor === 'undefined');
+}
+
+function isArray(o) {
+    return o && (o instanceof Array) || o.constructor === Array;
+}
+
+function isRegExp(o) {
+    return (o instanceof RegExp) ||
+         (typeof o.constructor !== 'undefined' && o.constructor.name === 'RegExp');
+}
+
+function isDate(o) {
+    return o && (o instanceof Date) ||
+           (typeof o.constructor !== 'undefined' && o.constructor.name === 'Date');
+}
+
+function isFunction(o) {
+    return o && (typeof o === 'function' || o instanceof Function);// ||
+           //(typeof o.constructor !== 'undefined' && (o.constructor||{}).name === 'Function');
+}
+
+function isObject(o) {
+  return o && o instanceof Object ||
+         (typeof o.constructor !== 'undefined' && o.constructor.name === 'Object');
 }
 
 function walk(object) {
@@ -116,42 +143,14 @@ function walk(object) {
     }
 }
 
-function getValue(o) { // see: https://developer.mozilla.org/en/JavaScript/Reference/Operators/Special/typeof
-    if (o === null) { return 'null'; }
-    if ( /^(string|boolean|number|undefined)$/.test(typeof o) ) {
-        return ''+stringify(o);
-    }
+/**
+    @param {any} object
+ */
+exports.dump = function(object) {
+    indentBy = 0;
+    output = '';
+    
+    walk(object);
+    outdent(false);
+    return output;
 }
-
-function stringify(o) {
-    return JSON.stringify(o);
-}
-
-function isUnwalkable(o) { // some objects are unwalkable, like Java native objects
-    return (typeof o === 'object' && typeof o.constructor === 'undefined');
-}
-
-function isArray(o) {
-    return o && (o instanceof Array) || o.constructor === Array;
-}
-
-function isRegExp(o) {
-    return (o instanceof RegExp) ||
-         (typeof o.constructor !== 'undefined' && o.constructor.name === 'RegExp');
-}
-
-function isDate(o) {
-    return o && (o instanceof Date) ||
-           (typeof o.constructor !== 'undefined' && o.constructor.name === 'Date');
-}
-
-function isFunction(o) {
-    return o && (typeof o === 'function' || o instanceof Function);// ||
-           //(typeof o.constructor !== 'undefined' && (o.constructor||{}).name === 'Function');
-}
-
-function isObject(o) {
-  return o && o instanceof Object ||
-         (typeof o.constructor !== 'undefined' && o.constructor.name === 'Object');
-}
-

--- a/templates/default/publish.js
+++ b/templates/default/publish.js
@@ -381,6 +381,20 @@
         // once for all
         view.nav = nav;
 
+        function generate(title, docs, filename) {
+            var data = {
+                title: title,
+                docs: docs
+            };
+            
+            var path = outdir + '/' + filename,
+                html = view.render('container.tmpl', data);
+            
+            html = helper.resolveLinks(html); // turn {@link foo} into <a href="foodoc.html">foo</a>
+            
+            fs.writeFileSync(path, html)
+        }
+        
         for (var longname in helper.longnameToUrl) {
             if ( hasOwnProp.call(helper.longnameToUrl, longname) ) {
                 var classes = find({kind: 'class', longname: longname});
@@ -415,20 +429,6 @@
 			).concat(files)
 		, 'index.html');
         
-        
-        function generate(title, docs, filename) {
-            var data = {
-                title: title,
-                docs: docs
-            };
-            
-            var path = outdir + '/' + filename,
-                html = view.render('container.tmpl', data);
-            
-            html = helper.resolveLinks(html); // turn {@link foo} into <a href="foodoc.html">foo</a>
-            
-            fs.writeFileSync(path, html)
-        }
         
         function generateTutorial(title, tutorial, filename) {
             var data = {


### PR DESCRIPTION
This is the third in a series of pull requests that allow JSDoc to be used with JSHint.

In this pull request, I've enabled the "latedef" test, which prevents variables from being used before they're declared. The diff is somewhat large and convoluted, but all it's doing is moving things around.

The next (and final) step: Disable some of the "relaxing options," which are all turned on right now. I'll do that in a single pull request if the diffs aren't too gnarly.
