### PR TITLE
@partial

### DIFF
--- a/plugins/partial.js
+++ b/plugins/partial.js
@@ -1,0 +1,30 @@
+/**
+    @overview Adds support for reusable partial jsdoc files.
+    @module plugins/partial
+    @author Ludo Antonov <ludo@hulu.com>
+ */
+
+var fs = require('fs');
+var path = require('path');
+
+exports.handlers = {
+    ///
+    /// Include a partial jsdoc
+    /// @param e
+    /// @param e.filename
+    /// @param e.source
+    ///
+    /// @example
+    ///     @partial "partial_doc.jsdoc"
+    ///
+    beforeParse: function(e) {
+        e.source = e.source.replace(/(@partial \".*\")+/g, function($) {
+            var pathArg = $.match(/\".*\"/)[0].replace(/"/g,'');
+            var fullPath =  path.join(e.filename , '..', pathArg);
+
+            var partialData = fs.readFileSync(fullPath);
+
+            return partialData;
+        });
+    }
+};


### PR DESCRIPTION
imho this should be part of the base set of supported tags, but a small plugin like that will definitely help a lot of people like me. 

We started using jsdoc for restful api documentation, and not having the ability re-use parameters from different api calls was just super painful.
