### PR TITLE
Make jsdoc script work with MinGW and Cygwin

### DIFF
--- a/jsdoc
+++ b/jsdoc
@@ -6,6 +6,7 @@ while [ -h "$SOURCE" ] ; do SOURCE="$(readlink "$SOURCE")"; done
 # Get a Windows path under MinGW or Cygwin
 BASEPATH="$( cd -P "$( dirname "$SOURCE" )" && (pwd -W 2>/dev/null || cygpath -w $(pwd) 2>/dev/null || pwd))"
 if [ "${BASEPATH:0:1}" != "/" ] ; then
+  BASEPATH="${BASEPATH//\\//}"
   # We need a extra slash for URLs
   UBASEPATH="/$BASEPATH"
 else
@@ -14,7 +15,7 @@ fi
 
 # for whatever reason, Rhino requires module paths to be valid URIs
 URLPATH="file://$UBASEPATH"
-URLPATH=`echo "$URLPATH" | sed -e 's/ /%20/g' -e 's#\\\\#/#g'`
+URLPATH=`echo "$URLPATH" | sed -e 's/ /%20/g'`
 ENCODEDBASEPATH=`echo "$BASEPATH" | sed -e 's/ /%20/g'`
 
 ARGS="$@"


### PR DESCRIPTION
On MinGW and Cygwin, we have different representations for pathnames,
neither of which Rhino understands. We also have to contend with '\',
which is not a legal URI character.

And we have to supply a third / after file:// (two before the null
hostname, and one before the start of the absolute path). Since Windows
paths don't start with /, we have to supply it in that case.

We handle the MinGW and Cygwin cases by asking for the information with
'pwd -W' for MinGW and 'cygpath $(pwd)' for Cygwin, before finally
falling back to pwd for everyone else. Then, if they don't start with '/'
we supply the extra '/' for the URL.
