### PR TITLE
Use the java facilities to handle path manipulations portably.

### DIFF
--- a/rhino_modules/path.js
+++ b/rhino_modules/path.js
@@ -7,24 +7,21 @@ var fileSeparator = exports.sep = java.lang.System.getProperty("file.separator")
  * e.g. if the path was 'path/to/something', the return value would be 'path/to'
  */
 exports.dirname = function(_path) {
-    var parts = _path.split(fileSeparator);
-    parts.pop();
-    _path = parts.join(fileSeparator);
-    return _path;
+    var f = new java.io.File(_path);
+    return String(f.getParent());
 };
 
 /**
  *  Returns the last item on a path
  */
 exports.basename = function(_path, ext) {
-    var base,
-        idx,
-        parts = _path.split(fileSeparator);
-    if (parts.length > 0) {
-        base = parts.pop();
-        idx = ext ? base.indexOf(ext) : -1;
+    var f = new java.io.File(_path);
+    var p = f.getParentFile();
+    var base = String(f.getName());
+    if (p != null) {
+        var idx = ext ? base.indexOf(ext) : -1;
         if (idx !== -1) {
-            base = Array.prototype.slice.call(base, 0, base.length - ext.length).join("");
+            base = base.substring(0, base.length - ext.length);
         }
     }
     return base;


### PR DESCRIPTION
This was causing it to mis-calculate the paths, and end up losing the
output directory entirely, and overwrite the template static files
with themselves, resulting in truncation to zero-length. Of course,
they were also missing in the output.

It was expecting to be able to split paths on
System.getProperty("path.separator"), but that describes how to put a
path together, not how to take one apart, which is more complicated.

In particular, in windows, / is as valid a separator as \ in all but a
few UI contexts.

And since we need to pass / in paths that may get turned into URI's,
it's important to handle this correctly.

Java already provides a File facility to handle these sorts of operations.
This patch makes use of java.io.File to:

1) Find the parent of a File for dirname.
2) Find the name of a File for basename.

It also now makes use of substring for removing the ext for basename,
rather than Array.prototype.slice + join(""). I'm not sure what that
was all about...  It does have the effect of ensuring it's a Javascript
String, but calling String() has the same benefit and is much more clear.

You can put that back if there was a reason for it, but it looks just
confused to me.
