### PR TITLE
Proposed fix for Issue #190 (default template truncates CSS files on Windows)

### DIFF
--- a/templates/default/publish.js
+++ b/templates/default/publish.js
@@ -237,7 +237,7 @@ exports.publish = function(taffyData, opts, tutorials) {
     fs.mkPath(outdir);
 
     // copy static files to outdir
-    var fromDir = env.dirname + '/' + templatePath + '/static',
+    var fromDir = env.dirname.replace(/\\/g, "/") + '/' + templatePath + '/static',
         staticFiles = fs.ls(fromDir, 3);
         
     staticFiles.forEach(function(fileName) {


### PR DESCRIPTION
Filenames provided by fs.ls already use slashes instead of backslashes so the replace(fromDir, toDir) did nothing. 

It might be better to replace the backslashes directly in jsdoc.js but I preferred the more specific fix since I haven't had the time yet to get familiar with the rest of the code.
