### PR TITLE
Markdown - Filters input EOL 2

### DIFF
--- a/plugins/markdown.js
+++ b/plugins/markdown.js
@@ -38,6 +38,8 @@ function getParser(parser, conf) {
         parser = require("evilstreak/markdown");
 
         return function(source) {
+            // filters EOL of source so evilstreak/markdown doesn't screw the pooch.
+            source = source.replace(/(\r\n|\n|\r)/g, '\n');
             return parser.renderJsonML(parser.toHTMLTree(source, conf.dialect));
         };
     } else {

--- a/plugins/test/specs/markdown.js
+++ b/plugins/test/specs/markdown.js
@@ -13,6 +13,8 @@ exports.handlers = {
      */
     newDoclet: function(e) {
         if (e.doclet.description) {
+            // filters EOL of source so evilstreak/markdown doesn't screw the pooch.
+            e.doclet.description = e.doclet.description.replace(/(\r\n|\n|\r)/g, '\n');
             e.doclet.description = mdParser.toHTML(e.doclet.description)
                 .replace( /&amp;/g, "&" ) // because markdown escapes these
                 .replace( /&lt;/g, "<" )

--- a/rhino_modules/jsdoc/readme.js
+++ b/rhino_modules/jsdoc/readme.js
@@ -32,6 +32,8 @@ function getParser(parser, conf) {
         parser = require('evilstreak/markdown');
 
         return function(source) {
+            // filters EOL of source so evilstreak/markdown doesn't screw the pooch.
+            source = source.replace(/(\r\n|\n|\r)/g, '\n');
             return parser.renderJsonML(parser.toHTMLTree(source, conf.dialect));
         };
     }

--- a/rhino_modules/jsdoc/tutorial.js
+++ b/rhino_modules/jsdoc/tutorial.js
@@ -68,6 +68,8 @@ exports.Tutorial.prototype.parse = function() {
 
         // markdown
         case exports.TYPES.MARKDOWN:
+            // filters EOL of source so evilstreak/markdown doesn't screw the pooch.
+            this.content = this.content.replace(/(\r\n|\n|\r)/g, '\n');
             return mdParser.toHTML(this.content)
                 .replace(/&amp;/g, '&') // because markdown escapes these
                 .replace(/&lt;/g, '<')


### PR DESCRIPTION
Is this working out for you hegemonic?

I changed a setting in git to try and stop it from converting line
endings when I get files or send them. By default it converts things and
the documentation on turning it off is sketchy at best. I found a lot of
people saying that turning it off can cause all sorts of unspecified
doom... anyway. . .

Since the evilstreak/markdown plugin expects files to use \n as the EOL
mark, and chokes to death on \r\n, I've added filters everywhere that
evilstreak is run.

Everywhere I added the filter I added an identical comment. So if we
wanted to wire up some system module or whatever, we could find the
alterations I made today and replace them with calls to some function
like:

``` javascript
/**
* Converts end of line markers into whatever you want.
* Automatically detects any of \r\n, \n, or \r and
* replaces it with the user specified EOL marker.
* @Param {String} text The text you want processed.
* @Param {String} newEOL The replacement for the current EOL marks.
* @returns {String} Returns the processed text.
*/
function convertEOL(text, newEOL) {
    return text.replace(/(\r\n|\n|\r)/g, newEOL);
}
```

While it would be easier to modify the evilstreak/markdown.js itself,
I'm avoiding doing so because we'd have to re-mod it if the upstream
resource is improved and we want to use it.
