### PR TITLE
Fix for issue #227 jsDocComment Found typos.

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -76,7 +76,7 @@ source code being documented, like methods provided by a third-party superclass:
         }
     }
 
-#### Event: jsDocCommentFound
+#### Event: jsdocCommentFound
 
 This is fired whenever a jsdoc comment is found.  It may or may not be associated
 with any code.  You might use this to modify the contents of a comment before it
@@ -253,7 +253,7 @@ of the event parameter. In general the goal is to construct a comment and then
 get an event to fire.  After the parser lets all of the node visitors have a
 look at the node, it looks to see if the event object has a ```comment```
 property and an ```event``` property.  If it has both, the event named in the event
-property is fired.  The event is usually "symbolFound" or "jsDocCommentFound",
+property is fired.  The event is usually "symbolFound" or "jsdocCommentFound",
 but theoretically, a plugin could define its own events and handle them.
 
 #### Example

--- a/test/specs/jsdoc/src/handlers.js
+++ b/test/specs/jsdoc/src/handlers.js
@@ -16,7 +16,7 @@ describe("jsdoc/src/handlers", function() {
     });
 
     describe("attachTo", function() {
-        it("should attach a 'jsDocCommentFound' handler to the parser", function() {
+        it("should attach a 'jsdocCommentFound' handler to the parser", function() {
             var callbacks = testParser.__bindings['jsdocCommentFound'];
             expect(callbacks).toBeDefined();
             expect(callbacks.length).toEqual(1);


### PR DESCRIPTION
All of the code refers to jsdocCommentFound but the documentation and
comments in the code refer to jsDocCommentFound. This confused someone
for understandable reasons. I've fixed the typos.
