### PR TITLE
Fixes issue #231 Broken jake install

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -30,7 +30,7 @@ task('default', [], function(params) {
 
 desc('Installs a plugin/template.');
 task('install', [], function(loc) {
-    var fs = require('fs'), util = require('util'), path = require('path'), wrench = require('wrench/wrench');
+    var fs = require('fs'), util = require('util'), path = require('path'), wrench = require('./nodejs_modules/wrench/wrench.js');
 
     if(!loc) {
         fail("You must specify the location of the plugin/template.");


### PR DESCRIPTION
Fixes issue #231, Broken: jake install

It looks like the location of wrench was moved since the last update of
`jakefile.js`
