### PR TITLE
added --version switch, fixes #303

### DIFF
--- a/jsdoc.js
+++ b/jsdoc.js
@@ -215,6 +215,10 @@ function main() {
     } else if (env.opts.test) {
         include('test/runner.js');
         process.exit(0);
+    } else if (env.opts.version) {
+        var info = JSON.parse(fs.readFileSync(path.join(__dirname, 'package.json'), 'utf8'));
+        console.log(info.version);
+        process.exit(0);
     }
 
     if (env.conf.plugins) {

--- a/lib/jsdoc/opts/args.js
+++ b/lib/jsdoc/opts/args.js
@@ -79,6 +79,7 @@ argParser.addOption('h', 'help',        false, 'Print this message and quit.');
 argParser.addOption('X', 'explain',     false, 'Dump all found doclet internals to console and quit.');
 argParser.addOption('q', 'query',       true,  'A query string to parse and store in env.opts.query. Example: foo=bar&baz=true', false, parseQuery);
 argParser.addOption('u', 'tutorials',   true,  'Directory in which JSDoc should search for tutorials.');
+argParser.addOption(null,'version',     false, 'Display the version number and quit.');
 
 //TODO [-R, recurseonly] = a number representing the depth to recurse
 //TODO [-f, filter] = a regex to filter on <-- this can be better defined in the configs?

--- a/test/specs/jsdoc/opts/args.js
+++ b/test/specs/jsdoc/opts/args.js
@@ -233,6 +233,13 @@ describe("jsdoc/opts/args", function() {
             expect(r.nocolor).toEqual(true);
         });
 
+        it("should accept a '--version' option and return an object with a 'version' property", function() {
+            args.parse(['--version']);
+            var r = args.get();
+
+            expect(r.version).toEqual(true);
+        });
+
         it("should accept a naked option (i.e. no '-') and return an object with a '_' property", function() {
             args.parse(['myfile1', 'myfile2']);
             var r = args.get();


### PR DESCRIPTION
It does seem a bit slow though. Usually you expect `myProgram --version` to be quite fast, but there is a noticeable delay before the version is shown with jsdoc. A bit of experimentation suggests to me that the delay is introduced by the large bank of `require('various/modules');` statements at the start of `main()`, so I guess it can't really be helped (unless one only requires the bare minimum modules needed for the `--version` switch and requires the rest after that. It would make the code not as easy to follow though).
