### PR TITLE
added linelength and absposition to meta

### DIFF
--- a/lib/jsdoc/doclet.js
+++ b/lib/jsdoc/doclet.js
@@ -130,7 +130,7 @@ function fixDescription(docletSrc) {
  */
 exports.Doclet = function(docletSrc, meta) {
     var newTags = [];
-    
+
     /** The original text of the comment from the source code. */
     this.comment = docletSrc;
     this.setMeta(meta);
@@ -286,7 +286,23 @@ exports.Doclet.prototype.setMeta = function(meta) {
          */
         this.meta.lineno = meta.lineno;
     }
-    
+
+    if (meta.absposition) {
+        /**
+            The line number of the code associated with this doclet.
+            @type number
+         */
+        this.meta.absposition = meta.absposition;
+    }
+
+    if (meta.linelength) {
+        /**
+            The line number of the code associated with this doclet.
+            @type number
+         */
+        this.meta.linelength = meta.linelength;
+    }
+
     if (meta.lineno) {
         /**
             The name of the file containing the code associated with this doclet.

--- a/lib/jsdoc/src/parser.js
+++ b/lib/jsdoc/src/parser.js
@@ -314,6 +314,8 @@ exports.Parser.prototype._makeEvent = function(node, extras) {
         lineno: extras.lineno || node.left.getLineno(),
         filename: extras.filename || this._currentSourceName,
         astnode: extras.astnode || node,
+        linelength: extras.linelength || node.getLength(),
+        absposition: extras.absposition || (node.getAbsolutePosition()) || 0,
         code: extras.code || aboutNode(node),
         event: extras.event || 'symbolFound',
         finishers: extras.finishers || [this.addDocletRef]
@@ -376,7 +378,9 @@ exports.Parser.prototype._visitNode = function(node) {
                 e = {
                     comment: commentSrc,
                     lineno: comment.getLineno(),
-                    filename: this._currentSourceName
+                    filename: this._currentSourceName,
+                    linelength: comment.getLength(),
+                    absposition: comment.getAbsolutePosition()
                 };
 
                 this.emit('jsdocCommentFound', e, this);
@@ -419,7 +423,9 @@ exports.Parser.prototype._visitNode = function(node) {
         }
 
         extras = {
-            lineno: node.getLineno()
+            lineno: node.getLineno(),
+            linelength: node.getLength(),
+            absposition: node.getAbsolutePosition()
         };
         e = this._makeEvent(node, extras);
 
@@ -427,7 +433,9 @@ exports.Parser.prototype._visitNode = function(node) {
     }
     else if (node.type == Token.FUNCTION || node.type == tkn.NAMEDFUNCTIONSTATEMENT) {
         extras = {
-            lineno: node.getLineno()
+            lineno: node.getLineno(),
+            linelength: node.getLength(),
+            absposition: node.getAbsolutePosition()
         };
         e = this._makeEvent(node, extras);
 


### PR DESCRIPTION
Patch to 'fix' #317

It adds 2 new properties meta.linelength and meta.absposition, so you can easily extract the code belonging to that node.
