### PR TITLE
Change protocol to git+https for dependencies URLs.

### DIFF
--- a/Jake/templates/package.json.tmpl
+++ b/Jake/templates/package.json.tmpl
@@ -18,12 +18,12 @@
 	],
 	"dependencies": {
 		"async": "0.1.22",
-		"crypto-browserify": "git://github.com/dominictarr/crypto-browserify.git#95c5d505",
-		"github-flavored-markdown": "git://github.com/hegemonic/github-flavored-markdown.git",
+		"crypto-browserify": "git+https://github.com/dominictarr/crypto-browserify.git#95c5d505",
+		"github-flavored-markdown": "git+https://github.com/hegemonic/github-flavored-markdown.git",
 		"js2xmlparser": "0.1.0",
 		"jshint": "0.9.1",
-		"markdown": "git://github.com/jsdoc3/markdown-js.git",
-		"taffydb":  "git://github.com/hegemonic/taffydb.git",
+		"markdown": "git+https://github.com/jsdoc3/markdown-js.git",
+		"taffydb":  "git+https://github.com/hegemonic/taffydb.git",
 		"underscore": "1.4.2",
 		"wrench":   "1.3.9"
 	},

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "jsdoc",
 	"version": "3.2.0-dev",
-	"revision": "1359085455394",
+	"revision": "1361370596838",
 	"description": "An API documentation generator for JavaScript.",
 	"keywords": [ "documentation", "javascript" ],
 	"licenses": [


### PR DESCRIPTION
Installation becomes an error in case of the environment(inside firewall, proxy, etc) where the git protocol is restricted.

```
# npm install git+https://github.com/jsdoc3/jsdoc.git
...
npm ERR! git clone git://github.com/dominictarr/crypto-browserify.git fatal: unable to connect to github.com:
npm ERR! git clone git://github.com/dominictarr/crypto-browserify.git github.com[0: 207.97.227.239]: errno=No error
...
```

Prease exclude git protocol in dependencies URLs.
