### PR TITLE
Fixed layout.tmpl to support IE8

### DIFF
--- a/templates/default/tmpl/layout.tmpl
+++ b/templates/default/tmpl/layout.tmpl
@@ -7,7 +7,7 @@
     <script src="scripts/prettify/prettify.js"> </script>
     <script src="scripts/prettify/lang-css.js"> </script>
     <!--[if lt IE 9]>
-      <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <link type="text/css" rel="stylesheet" href="styles/prettify-tomorrow.css">
     <link type="text/css" rel="stylesheet" href="styles/jsdoc-default.css">


### PR DESCRIPTION
IE8 doesn't properly support two forward slash notation, so the html5 shiv wasn't getting loaded.
