### PR TITLE
@default tag: added support for object literal defaults

### DIFF
--- a/lib/jsdoc/tag/dictionary/definitions.js
+++ b/lib/jsdoc/tag/dictionary/definitions.js
@@ -251,9 +251,9 @@ exports.defineTags = function(dictionary) {
                     // TODO: handle escaped quotes in values
                     doclet.defaultvalue = 'null';
                 }
-                else if (doclet.meta.code.type === 'OBJECTLIT'){
+                else if (doclet.meta.code.type === 'OBJECTLIT') {
                     doclet.defaultvalue = String(doclet.meta.code.node.toSource());
-                    doclet.defaultobject = true;
+                    doclet.defaultvaluetype = 'object';
                 }
             }
         }

--- a/templates/default/static/styles/jsdoc-default.css
+++ b/templates/default/static/styles/jsdoc-default.css
@@ -202,6 +202,7 @@ h6
 .details ul { list-style-type: none; }
 .details li { margin-left: 30px; padding-top: 6px; }
 .details pre.prettyprint { margin: 0 }
+.details .object-value { padding-top: 0; }
 
 .description {
 	margin-bottom: 1em;

--- a/templates/default/tmpl/details.tmpl
+++ b/templates/default/tmpl/details.tmpl
@@ -1,12 +1,12 @@
 <?js
 var data = obj;
 var self = this;
-var default_object_css = '';
+var defaultObjectClass = '';
 
 // Check if the default value is an object, if so, apply code highlighting
-if (data.defaultvalue && data.defaultobject){
+if (data.defaultvalue && data.defaultvaluetype === 'object') {
     data.defaultvalue = "<pre class=\"prettyprint\"><code>" + data.defaultvalue + "</code></pre>";
-    default_object_css = ' style="padding-top: 0;" ';
+    defaultObjectClass = ' class="object-value"';
 }
 ?>
 <dl class="details">
@@ -67,7 +67,7 @@ if (data.defaultvalue && data.defaultobject){
     <?js if (data.defaultvalue) {?>
     <dt class="tag-default">Default Value:</dt>
     <dd class="tag-default"><ul class="dummy">
-            <li<?js= default_object_css ?>><?js= data.defaultvalue ?></li>
+            <li<?js= defaultObjectClass ?>><?js= data.defaultvalue ?></li>
         </ul></dd>
     <?js } ?>
     

--- a/test/fixtures/defaulttag.js
+++ b/test/fixtures/defaulttag.js
@@ -37,3 +37,11 @@ var header = getHeaders(request);
     @default
  */
 var obj = { value_a : 'a', value_b : 'b' };
+
+/**
+ * @default
+ */
+var multilineObject = {
+    value_a : 'a',
+    value_b : 'b'
+};

--- a/test/specs/tags/defaulttag.js
+++ b/test/specs/tags/defaulttag.js
@@ -7,7 +7,8 @@ describe("@default tag", function() {
 		rerrored = (docSet.getByLongname('rerrored') || [])[0],
 		win = (docSet.getByLongname('win') || [])[0],
 		header = (docSet.getByLongname('header') || [])[0],
-        obj = docSet.getByLongname('obj')[0];
+        obj = docSet.getByLongname('obj')[0],
+        multilineObject = docSet.getByLongname('multilineObject')[0];
 
     it('When symbol set to null has a @default tag with no text, the doclet\'s defaultValue property should be: null', function() {
         expect(request.defaultvalue).toBe('null');
@@ -37,9 +38,14 @@ describe("@default tag", function() {
         expect(header.defaultvalue).toBeUndefined();
     });
 
-    it('When symbol has a @default tag with an object.', function(){
+    it('When symbol has a @default tag with an object, the doclet\'s defaultValue property should contain the stringified object', function() {
         var expected_value = "{value_a: 'a', value_b: 'b'}";
         expect(obj.defaultvalue).toEqual(expected_value);
-    })
+    });
+
+    it('When symbol has a @default tag with a multiline object, the doclet\'s defaultValue property should contain the properly stringified object', function() {
+        var expected_value = "{value_a: 'a', value_b: 'b'}";
+        expect(obj.defaultvalue).toEqual(expected_value);
+    });
 
 });


### PR DESCRIPTION
Some fields contain objects as their default value. They are now stored as a string and, in the default template, displayed with syntax highlighting.

``` javascript
/**
    @default
 */
var obj = { value_a : 'a', value_b : 'b' };
```

Becomes

![object default 2](https://f.cloud.github.com/assets/1655575/482760/6596cc94-b8a6-11e2-86e1-2822bd8ac71b.png)

The code is covered by a unit test.

The CSS was changed to not have the highlighted code disrupt the border next to the field details.
