### PR TITLE
@augments tag: Inherited members correctly identify their origin

### DIFF
--- a/lib/jsdoc/augment.js
+++ b/lib/jsdoc/augment.js
@@ -90,7 +90,10 @@ function getAdditions(doclets, docs, longnames) {
                 for (var k = 0, kk = members.length; k < kk; k++) {
                     member = doop(members[k]);
 
-                    member.inherits = member.longname;
+                    if(!member.inherited)
+                    {
+                        member.inherits = member.longname;
+                    }
                     member.inherited = true;
 
                     member.memberof = doc.longname;

--- a/test/specs/tags/augmentstag.js
+++ b/test/specs/tags/augmentstag.js
@@ -80,6 +80,15 @@
         expect(bazMethod3.memberof).toBe("Baz");
     });
 
+     it('(Grand)children correctly identify the original source of inherited members', function(){
+         expect(fooProp1.inherits).not.toBeDefined();
+         expect(barProp3.inherits).not.toBeDefined();
+         expect(barProp1.inherits).toBe("Foo#prop1");
+         expect(bazProp2.inherits).toBe("Foo#prop2");
+         expect(bazProp3.inherits).toBe("Bar#prop3");
+         expect(bazMethod1.inherits).toBe("Foo#method1");
+     });
+
     it('When an object is extended, and it overrides an ancestor property, the child does not include docs for the ancestor property.', function() {
         expect(bazProp1All.length).toBe(1);
     });


### PR DESCRIPTION
'inherits' tag is only written if it is empty. Before this change all members inherited from the direct parent, even if it actually came from a grandparent.

For example:

``` javascript

/**
 * @constructor
 */
function Vehicle (){
    /** The amount of wheels */
    this.Wheels = 4;
}

/**
 * @constructor
 * @augments Vehicle
 */
function CommercialVehicle (){
    /** Useful load */
    this.Payload = 1000;
}

/**
 * @constructor
 * @augments CommercialVehicle
 */
function Bus(){
    /** Amount of passengers (excluding driver) */
    this.Passengers = 60;
}
```

Now correctly indicates that the 'Wheels' property was defined in 'Vehicle', and not in 'CommercialVehicle'.

The change is covered by unit testing.
