### PR TITLE
Markdown code highlighting

### DIFF
--- a/jsdoc.js
+++ b/jsdoc.js
@@ -242,11 +242,6 @@ function main() {
             process.exit(0);
         }
 
-        if (env.opts.tutorials) {
-            jsdoc.tutorial.resolver.load(env.opts.tutorials);
-            jsdoc.tutorial.resolver.resolve();
-        }
-
         env.opts.template = (function() {
             var publish = env.opts.template || 'templates/default';
             // if we don't find it, keep the user-specified value so the error message is useful
@@ -258,6 +253,16 @@ function main() {
         }
         catch(e) {
             throw new Error('Unable to load template: ' + e.message || e);
+        }
+
+        if (env.opts.tutorials) {
+            // Set up code highlighter for markdown plugins
+            if (template.highlight && typeof template.highlight === 'function') {
+                env.opts.highlighter = template.highlight;
+            }
+
+            jsdoc.tutorial.resolver.load(env.opts.tutorials);
+            jsdoc.tutorial.resolver.resolve();
         }
 
         // templates should include a publish.js file that exports a "publish" function

--- a/lib/jsdoc/util/markdown.js
+++ b/lib/jsdoc/util/markdown.js
@@ -55,16 +55,22 @@ function getParseFunction(parser, conf) {
     var parse;
 
     if (parser === parsers.marked) {
+        var options = {
+            gfm: true,
+            tables: true,
+            breaks: false,
+            pedantic: false,
+            sanitize: true,
+            smartLists: true,
+            langPrefix: 'lang-'
+        };
+
+        if(env.opts.highlighter && typeof env.opts.highlighter === 'function') {
+            options.highlight = env.opts.highlighter;
+        }
+
         parser = require(parser);
-        parser.setOptions({
-                gfm: true,
-                tables: true,
-                breaks: false,
-                pedantic: false,
-                sanitize: true,
-                smartLists: true,
-                langPrefix: 'lang-'
-            });
+        parser.setOptions(options);
         parse = function(source) {
             source = escapeUnderscores(source);
             return parser(source)

--- a/templates/default/publish.js
+++ b/templates/default/publish.js
@@ -557,3 +557,7 @@ exports.publish = function(taffyData, opts, tutorials) {
     }
     saveChildren(tutorials);
 };
+
+exports.highlight = function(code, lang) {
+    return '<pre class="prettyprint lang-' + lang + '"><code>' + code + '</code></pre>';
+};

--- a/test/specs/jsdoc/util/markdown.js
+++ b/test/specs/jsdoc/util/markdown.js
@@ -92,5 +92,34 @@ describe('jsdoc/util/markdown', function() {
                 '<p>{@link MyClass#_x} and {@link MyClass#_y}</p>');
             restoreMarkdownConf(storage);
         });
+
+        it('should use the specified highlighter when the marked parser is enabled', function() {
+            var storage = setMarkdownConf({parser: 'marked'});
+            var temp = env.conf.highlighter;
+            env.opts.highlighter = function () { };
+            var return_val = 'highlighted_code';
+            spyOn(env.opts, 'highlighter').andReturn(return_val);
+            var source = '```javascript\ncode();\n```';
+
+            var parser = markdown.getParser();
+            expect(parser(source)).toEqual('<pre><code class="lang-javascript">' + return_val + '</code></pre>');
+            expect(env.opts.highlighter).toHaveBeenCalledWith('code();','javascript');
+
+            restoreMarkdownConf(storage);
+            env.opts.highlighter = temp;
+        });
+
+        it('should function without a specified highlighter when the marked parser is enabled', function() {
+            var storage = setMarkdownConf({parser: 'marked'});
+            var temp = env.conf.highlighter;
+            delete env.conf.highlighter;
+            var source = '```javascript\ncode();\n```';
+
+            var parser = markdown.getParser();
+            expect(parser(source)).toEqual('<pre><code class="lang-javascript">code();</code></pre>');
+
+            restoreMarkdownConf(storage);
+            env.opts.highlighter = temp;
+        });
     });
 });


### PR DESCRIPTION
Allows the template to expose a highlight function (which takes a code and lang param) to highlight code samples in markdown (when the marked parser is used) similarly to code examples in jsdoc comments. The change is covered by unit tests.

Before:

![markdown highlighting before](https://f.cloud.github.com/assets/1655575/507609/99d5a26a-bd73-11e2-90ae-89715752acd1.png)

After:

![markdown highlighting after](https://f.cloud.github.com/assets/1655575/507610/a1d2d208-bd73-11e2-96d7-5085cb6bd610.png)

I couldn't figure out how to do this with the evilstreak parser, but maybe someone else would be able to do that at some point in the future.

It's completely backwards compatible: if the template doesn't expose a highlight function the behavior is as it was before this change.
