### PR TITLE
parseComplete event now also supplies doclets

### DIFF
--- a/lib/jsdoc/src/parser.js
+++ b/lib/jsdoc/src/parser.js
@@ -91,7 +91,8 @@ exports.Parser.prototype.parse = function(sourceFiles, encoding) {
     }
 
     this.emit('parseComplete', {
-        sourcefiles: parsedFiles
+        sourcefiles: parsedFiles,
+        doclets: this._resultBuffer
     });
 
     return this._resultBuffer;


### PR DESCRIPTION
The parseComplete event only supplied plugins a list of files that
have been looked at before, now it also supplies the parsed doclets.

My use case is that I would like to be able to process some changes in the doclets after the initial parse and before post-processing. In our code we can almost always set a class's properties as a parameter, so we would like to create a 'toparam' tag which copies a property's description and type to the constructor's parameters. To do this I need to be able to modify the doclets object. I can't do this after post-processing, because another one of my plugins copies the parameters to other objects which inherit the constructor parameters.

I'm having some issues with writing the unit test though.

``` javascript
spy.mostRecentCall.args[0].doclets
```

Gives an empty array in the unit test, (`{"sourcefiles":["[[string0]]"],"doclets":[]}`)
 but when I copy the string (`var bar = false;`) from the parseComplete unit test to a file and then run jsdoc with the eventDumper plugin I actually get an array with objects. 

``` javascript
{
    "type": "parseComplete",
    "content": {
        "sourcefiles": "/home/eh/Documents/jsdoc/file.js",
        "doclets": "[object Object]"
    }
}
```
