### PR TITLE
Changes to allow target and text in {@link target text} to be separated ...

### DIFF
--- a/lib/jsdoc/tag/inline.js
+++ b/lib/jsdoc/tag/inline.js
@@ -61,7 +61,7 @@ exports.replaceInlineTags = function(string, replacers) {
 
     string = string || '';
     Object.keys(replacers).forEach(function(replacer) {
-        var tagRegExp = new RegExp('\\{@' + replacer + '\\s+(.+?)\\}', 'gi');
+        var tagRegExp = new RegExp('\\{@' + replacer + '\\s+((?:.|\n)+?)\\}', 'gi');
         var matches;
         // call the replacer once for each match
         while ( (matches = tagRegExp.exec(string)) !== null ) {

--- a/lib/jsdoc/util/templateHelper.js
+++ b/lib/jsdoc/util/templateHelper.js
@@ -256,11 +256,13 @@ function splitLinkText(text) {
     // if a pipe is not present, we split on the first space
     splitIndex = text.indexOf('|');
     if (splitIndex === -1) {
-        splitIndex = text.indexOf(' ');
+        splitIndex = text.search(/\s/);
     }
 
     if (splitIndex !== -1) {
         linkText = text.substr(splitIndex + 1);
+        // Normalize subsequent newlines to a single space.
+        linkText = linkText.replace(/\n+/, ' ');
         target = text.substr(0, splitIndex);
     }
 

--- a/test/specs/jsdoc/util/templateHelper.js
+++ b/test/specs/jsdoc/util/templateHelper.js
@@ -1170,6 +1170,22 @@ describe("jsdoc/util/templateHelper", function() {
             expect(output).toBe('This is a <a href="path/to/test.html">test</a>.');
         });
 
+        it('should allow linebreaks to separate url from link text', function() {
+            var input = 'This is a {@link\ntest\ntest}.',
+                output = helper.resolveLinks(input);
+
+            expect(output).toBe('This is a <a href="path/to/test.html">test</a>.');
+        });
+
+
+        it('should normalize additional newlines to spaces', function() {
+            var input = 'This is a {@link\ntest\ntest\n\ntest}.',
+                output = helper.resolveLinks(input);
+
+            expect(output).toBe('This is a <a href="path/to/test.html">test test</a>.');
+        });
+
+
         it('should allow tabs between link tag and content', function() {
             var input = 'This is a {@link\ttest}.',
                 output = helper.resolveLinks(input);


### PR DESCRIPTION
...by newlines and for text to contain newlines.

At the moment jsdoc does not interpret the following as a link:

``` javascript
/**
  * {@link some_long_target 
  *  text_to_display}
  */
```

because of the presence of a newline between the target and the text but code formatters that format comments will typically want to break between the target and text at the first opportunity. For instance javascript-mode and js2-mode in Emacs both do this. The patch allows for the presence of such newlines. For the record: the presence of a newline between `@link` and the target was already accepted.

The patch also normalizes sequences of newlines to a single space because I find ugly the presence inside `<a>` of newlines caused by an artifact of source formatting. I realize opinions could vary on this from "keep them" to "all spaces should be normalized".

I've added new tests to test it, and It does not break old tests. But I do not know the jsdoc ecosystem well enough to know whether I'm breaking some expectations from users or some use case I'm not thinking of.
