### PR TITLE
Added underscore plugin

### DIFF
--- a/plugins/test/fixtures/underscore.js
+++ b/plugins/test/fixtures/underscore.js
@@ -1,0 +1,22 @@
+'use strict';
+
+/** This doclet will be shown by default, just like normal. */
+function normal() {}
+
+/** This doclet will be hidden by default because it begins with an underscore. */
+function _hidden() {}
+
+/**
+ * Klass class
+ * @class
+ */
+function Klass() {
+    /** This is a private property of the class, and should not. */
+    this._privateProp = null;
+
+    /**
+     * This is a property explicitly marked as private.
+     * @private
+     */
+    this.privateProp = null;
+}

--- a/plugins/test/specs/underscore.js
+++ b/plugins/test/specs/underscore.js
@@ -1,0 +1,35 @@
+'use strict';
+
+describe('underscore plugin', function () {
+    var parser = jasmine.createParser();
+    var path = require('jsdoc/path');
+
+    var docSet;
+
+    var pluginPath = 'plugins/underscore';
+    var fixturePath = 'plugins/test/fixtures/underscore';
+    var pluginPathResolved = path.join(env.dirname, pluginPath);
+    var plugin = require(pluginPathResolved);
+
+    require('jsdoc/plugins').installPlugins([pluginPathResolved], parser);
+    docSet = jasmine.getDocSetFromFile(fixturePath + '.js', parser);
+
+    it('should not mark normal, public properties as private', function() {
+        // Base line tests
+        var normal = docSet.getByLongname('normal');
+        expect(normal[0].access).toBeUndefined();
+
+        var realPrivate = docSet.getByLongname('Klass#privateProp');
+        expect(realPrivate[0].access).toEqual('private');
+    });
+
+    it('should hide doclet for symbols beginning with an underscore under normal circumstances', function () {
+        var hidden = docSet.getByLongname('_hidden');
+        expect(hidden[0].access).toEqual('private');
+    });
+
+    it('picks up "this"', function() {
+        var privateUnderscore = docSet.getByLongname('Klass#_privateProp');
+        expect(privateUnderscore[0].access).toEqual('private');
+    });
+});

--- a/plugins/underscore.js
+++ b/plugins/underscore.js
@@ -1,0 +1,21 @@
+'use strict';
+
+/**
+ * Removes all symbols that begin with an underscore from the doc output. If
+ * you're using underscores to denote private variables in modules, this
+ * automatically hides them.
+ *
+ * @module plugins/underscore
+ * @author Daniel Ellis <coug36@gmail.com>
+ */
+
+exports.handlers = {
+    newDoclet: function(e) {
+        var doclet = e.doclet;
+
+        // Ignore comment blocks for all symbols that begin with underscore
+        if (doclet.name.charAt(0) === '_' || doclet.name.substr(0, 6) === 'this._') {
+            doclet.access = 'private';
+        }
+    }
+};


### PR DESCRIPTION
This plugin removes all symbols that begin with an underscore from doc output. This comes in handy when you're using underscores to indicate private variables that you want documented in code or internal docs, but not in published api documentation.
