### PR TITLE
Fix for jump to line in source file

### DIFF
--- a/templates/default/static/scripts/linenumber.js
+++ b/templates/default/static/scripts/linenumber.js
@@ -9,7 +9,7 @@
         numbered = source.innerHTML.split('\n');
         numbered = numbered.map(function(item) {
             counter++;
-            return '<span id="line' + counter + '"></span>' + item;
+            return '<span id="line' + counter + '" class="line"></span>' + item;
         });
 
         source.innerHTML = numbered.join('\n');

--- a/templates/default/static/styles/jsdoc-default.css
+++ b/templates/default/static/styles/jsdoc-default.css
@@ -242,7 +242,7 @@ h6
 	border-left: 3px #ddd solid;
 }
 
-.prettyprint code span
+.prettyprint code span.line
 {
   display: inline-block;
 }


### PR DESCRIPTION
In some browsers jump to line in source file didn't work.
Not working in the following browsers:
Google Chrome 28.0.1500.95 m
Opera 15.0.1147.130
IE8

Testlink: http://fabricjs.com/docs/fabric.js.html#line15942
