### PR TITLE
Plugin to automatically extract a summary, if missing, from the first se...

### DIFF
--- a/plugins/autosummary.js
+++ b/plugins/autosummary.js
@@ -2,12 +2,12 @@
     @overview This plugin creates a summary tag, if missing, from the first sentence in the description tag.
     @module plugins/autosummary
     @author Mads Bondo Dydensborg <mbd@dbc.dk>
- */
+*/
 
 exports.handlers = {
     /**
         Auto generate summaries, if missing, from description, if present.
-     */
+    */
     newDoclet: function(e) {
         // If the summary is missing, grab the first sentence from the description
         // and use that.
@@ -20,17 +20,15 @@ exports.handlers = {
                 // This is an excerpt of something that is possibly HTML. 
                 // Balance it using a stack. Assume it was initially balanced.
                 var tags = e.doclet.summary.match(/<[^>]+>/g);
-                var stack = new Array();
-                for (tag in tags) {
+                var stack = [];
+                for (var tag in tags) {
                     if (tags[tag].search("/") <= 0) {
                         // start tag -- push onto the stack
                         stack.push(tags[tag]);
-                    } else if (tags[tag].search("/") == 1) {
+                    } else if (tags[tag].search("/") === 1) {
                         // end tag -- pop off of the stack
                         stack.pop();
-                    } else {
-                        // self-closing tag -- do nothing
-                    }
+                    } // else { // self-closing tag -- do nothing }
                 }
                 // stack should now contain only the start tags of the broken elements,
                 // the most deeply-nested start tag at the top


### PR DESCRIPTION
...ntence in the description

This plugin (tries to) extract a summary, if missing, from the first sentence in the description.

It does this by splitting at the first . that is followed by a whitespace or an HTML tag. Afterwards, it appends a ., balances any HTML tags and removes a begin-end pair of P tags.

The result is pretty useful, if the documenter has not "bothered" to write a summary and description tag.

I started a discussion about this a few months back:

https://groups.google.com/forum/?hl=en#!searchin/jsdoc-users/brief/jsdoc-users/00W9j4y_pj4/lOpHkXa3tQ0J

I am sorry to say, that I did not manage to create a change branch, or anything. Apologies. I hope that this pull can go into the source code anyway, as it is quite isolated from the rest of the code.

There are no tests - I can only say that it works for me.
