### PR TITLE
Account for relative jsdoc symlinks.

### DIFF
--- a/jsdoc
+++ b/jsdoc
@@ -2,7 +2,14 @@
 
 # rhino discards the path to the current script file, so we must add it back
 SOURCE="$0"
-while [ -h "$SOURCE" ] ; do SOURCE="$(readlink "$SOURCE")"; done
+while [ -h "$SOURCE" ] ; do
+  NEXTSOURCE="$(readlink "$SOURCE")"
+  if [[ "$NEXTSOURCE" = /* ]]; then
+    SOURCE="$NEXTSOURCE"
+  else
+    SOURCE="$(dirname $SOURCE)/$NEXTSOURCE"
+  fi
+done
 # Get a Windows path under MinGW or Cygwin
 BASEPATH="$( cd -P "$( dirname "$SOURCE" )" && (pwd -W 2>/dev/null || cygpath -w $(pwd) 2>/dev/null || pwd))"
 if [ "${BASEPATH%${BASEPATH#?}}" != "/" ] ; then


### PR DESCRIPTION
This happens when you install jsdoc via homebrew on Mac OS X. The jsdoc binary is actually a link to "../Cellar/jsdoc3/3.2.0/bin/jsdoc", which without this patch the BASEPATH line below tries to cd up a level from the current working directory and into a non-existent Cellar directory.

To reproduce, run `brew install jsdoc` followed by `jsdoc --help`. You'll get an error message like this:

```
$ jsdoc --help
/usr/local/bin/jsdoc: line 7: cd: ../Cellar/jsdoc3/3.2.0/bin: No such file or directory
Error: Could not find or load main class org.mozilla.javascript.tools.shell.Main
```
