### PR TITLE
Fix for win32

### DIFF
--- a/lib/jsdoc/util/runtime.js
+++ b/lib/jsdoc/util/runtime.js
@@ -24,6 +24,9 @@ function pathToUri(filepath) {
     uri = uri.replace(/^:?([A-Za-z]\:)?/, '');
     // replace spaces with %20
     uri = uri.replace(/\s/g, '%20');
+	// replace back slash with forward slash
+	uri = uri.replace(/\\/g, '/');
+	
     // prepend drive (if present)
     if (drive) {
         uri = drive + ':' + uri;
@@ -145,10 +148,9 @@ exports.getRuntime = function() {
  * @return {object} The require path for the runtime-specific implementation of the module.
  */
 exports.getModulePath = function(partialPath) {
-    var modulePath = [env.dirname, runtime, partialPath].join('/').replace(/ /g, '%20');
-    if (os.platform() === 'win32') {
-        modulePath = pathToUri(modulePath);
-    }
-    
-    return modulePath;
+	if (os.platform() === 'win32') {
+		return partialPath;
+	}
+	
+	return [env.dirname, runtime, partialPath].join('/').replace(/ /g, '%20');
 };


### PR DESCRIPTION
I couldn't make jsdoc work from command line on windows (32bit). So I had a look at the code and a change to getModulePath function made it work. The pathToUri is also wrong because the backslash should be replaced by forward slash (anyway is now removed from any execution path with this patch).
