### PR TITLE
Allow setting markdown parser options

### DIFF
--- a/lib/jsdoc/util/markdown.js
+++ b/lib/jsdoc/util/markdown.js
@@ -76,10 +76,12 @@ function unescapeUrls(source) {
  * @throws {Error} If the name does not correspond to a known parser.
  */
 function getParseFunction(parserName, conf) {
-    var marked = require('marked');
-    var parserFunction;
-
     conf = conf || {};
+    
+    var marked = require('marked');
+    marked.setOptions(conf);
+    
+    var parserFunction;
 
     if (parserName === parserNames.marked) {
         parserFunction = function(source) {


### PR DESCRIPTION
Makes it possible again to set parser options. Currently it is no longer possible to do this. The most important option is enabling [hard breaks](https://github.com/chjj/marked#breaks).

After this change you can do the following:

``` js
{
  "plugins": [ "plugins/markdown" ],
  "markdown": {
    "breaks": true
  }
}
```
