### PR TITLE
Show line numbers in source code.

### DIFF
--- a/templates/default/static/styles/jsdoc-default.css
+++ b/templates/default/static/styles/jsdoc-default.css
@@ -239,12 +239,16 @@ h6
 	margin: 0;
 	background-color: #fff;
 	color: #000;
-	border-left: 3px #ddd solid;
 }
 
 .prettyprint code span.line
 {
   display: inline-block;
+}
+
+.prettyprint .linenums li
+{
+  border-left: 3px #ddd solid;
 }
 
 .params, .props

--- a/templates/default/tmpl/source.tmpl
+++ b/templates/default/tmpl/source.tmpl
@@ -3,6 +3,6 @@
 ?>
     <section>
         <article>
-            <pre class="prettyprint source"><code><?js= data.code ?></code></pre>
+            <pre class="prettyprint source linenums"><code><?js= data.code ?></code></pre>
         </article>
     </section>


### PR DESCRIPTION
It would be great if we could actually see line numbers in source code snippets. Fortunately prettify supports this and it's trivial to implement in jsdoc.

I'd love to see branch 3.2.x updated with this pull request so that it can be installed from npm with line numbers enabled.

Thank you for your great work!
