### PR TITLE
Fix jsdoc #535: @member and @constant with only type create incorrect do...

### DIFF
--- a/lib/jsdoc/tag/dictionary/definitions.js
+++ b/lib/jsdoc/tag/dictionary/definitions.js
@@ -208,9 +208,12 @@ exports.defineTags = function(dictionary) {
     
     dictionary.defineTag('constant', {
         canHaveType: true,
+        canHaveName: true,
         onTagged: function(doclet, tag) {
             setDocletKindToTitle(doclet, tag);
-            setDocletNameToValue(doclet, tag);
+            if (tag.value && tag.value.name) {
+                doclet.addTag('name', tag.value.name);
+            }
             if (tag.value && tag.value.type) {
                 doclet.type = tag.value.type;
             }
@@ -430,9 +433,12 @@ exports.defineTags = function(dictionary) {
     
     dictionary.defineTag('member', {
         canHaveType: true,
+        canHaveName: true,
         onTagged: function(doclet, tag) {
             setDocletKindToTitle(doclet, tag);
-            setDocletNameToValue(doclet, tag);
+            if (tag.value && tag.value.name) {
+                doclet.addTag('name', tag.value.name);
+            }
             if (tag.value && tag.value.type) {
                 doclet.type = tag.value.type;
             }

--- a/test/fixtures/constanttag.js
+++ b/test/fixtures/constanttag.js
@@ -4,3 +4,6 @@ var FOO = 1;
 /** @const BAR */
 
 /** @const {string} BAZ */
+
+/** @const {number} */
+var FOOS = 2;

--- a/test/fixtures/membertag.js
+++ b/test/fixtures/membertag.js
@@ -3,3 +3,6 @@ var x;
 
 /** @var foobar */
 /** @var {string} baz */
+
+/** @member {Object} */
+var y;

--- a/test/specs/tags/constanttag.js
+++ b/test/specs/tags/constanttag.js
@@ -2,12 +2,15 @@ describe("@constant tag", function() {
     var docSet = jasmine.getDocSetFromFile('test/fixtures/constanttag.js'),
         FOO = docSet.getByLongname('FOO')[0],
         BAR = docSet.getByLongname('BAR')[0],
-        BAZ = docSet.getByLongname('BAZ')[0];
+        BAZ = docSet.getByLongname('BAZ')[0],
+        FOOS = docSet.getByLongname('FOOS')[0];
+
 
     it("sets the doclet's 'kind' property to 'constant'", function() {
         expect(FOO.kind).toBe('constant');
         expect(BAR.kind).toBe('constant');
         expect(BAZ.kind).toBe('constant');
+        expect(FOOS.kind).toBe('constant');
     });
 
     it("If used as a standalone, takes the name from the code", function() {
@@ -24,5 +27,13 @@ describe("@constant tag", function() {
         expect(BAZ.type.names).toBeDefined();
         expect(BAZ.type.names.length).toBe(1);
         expect(BAZ.type.names[0]).toBe('string');
+    });
+
+    it("If used with only a type, takes the name from the code", function() {
+        expect(FOOS.name).toBe('FOOS');
+        expect(FOOS.type).toBeDefined();
+        expect(Array.isArray(FOOS.type.names)).toBeTruthy();
+        expect(FOOS.type.names.length).toBe(1);
+        expect(FOOS.type.names[0]).toBe('number');
     });
 });

--- a/test/specs/tags/membertag.js
+++ b/test/specs/tags/membertag.js
@@ -2,12 +2,14 @@ describe("@member tag", function() {
     var docSet = jasmine.getDocSetFromFile('test/fixtures/membertag.js'),
         doc = docSet.getByLongname('x')[0],
         doc2 = docSet.getByLongname('foobar')[0],
-        doc3 = docSet.getByLongname('baz')[0];
+        doc3 = docSet.getByLongname('baz')[0],
+        doc4 = docSet.getByLongname('y')[0];
 
     it("sets the doclet's 'kind' property to 'member'", function() {
         expect(doc.kind).toBe('member');
         expect(doc2.kind).toBe('member');
         expect(doc3.kind).toBe('member');
+        expect(doc4.kind).toBe('member');
     });
 
     it("If specified with a name, sets the doclet's name property", function() {
@@ -21,5 +23,16 @@ describe("@member tag", function() {
         expect(Array.isArray(doc3.type.names)).toBeTruthy();
         expect(doc3.type.names.length).toBe(1);
         expect(doc3.type.names[0]).toBe('string');
+    });
+
+    it("If specified with a type but no name, sets the doclet's name from the following JavaScript syntax", function() {
+        expect(doc4.name).toBe('y');
+    });
+
+    it("If specified with a type but no name, sets the doclet's type appropriately", function() {
+        expect(doc4.type).toBeDefined();
+        expect(Array.isArray(doc4.type.names)).toBeTruthy();
+        expect(doc4.type.names.length).toBe(1);
+        expect(doc4.type.names[0]).toBe('Object');
     });
 });


### PR DESCRIPTION
...clet. 

This will fix #535.

The added tests fail without the fix, but pass with the fix.

Only the name and the type are examined because `@constant` and `@member` don't support descriptions according to the usejsdoc.org documentation.
