### PR TITLE
Replace env.pwd with process.cwd() to make jsdoc work under Cygwin.

### DIFF
--- a/lib/jsdoc/src/scanner.js
+++ b/lib/jsdoc/src/scanner.js
@@ -28,7 +28,7 @@ exports.Scanner.prototype.scan = function(searchPaths, depth, filter) {
     var isFile;
 
     var filePaths = [];
-    var pwd = env.pwd;
+    var pwd = process.cwd();
     var self = this;
 
     searchPaths = searchPaths || [];


### PR DESCRIPTION
Under Cygwin the $PWD environment variable (and the output of the "pwd" command, or "realpath .") will say something like "/home/foo", whereas the real Windows path is "C:\cygwin\home\foo".  For programs operating entirely inside Cygwin this all works fine, but regular Windows programs can't directly use Cygwin paths to construct an absolute (Windows) path.  This patch changes jsdoc from using env.pwd (which has a Cygwin path) to using process.cwd() (which has a real Windows path).  With just this one change regular jsdoc functionality now seems to work fine under Cygwin.  I apologize in advance for not making a test for this change, the test framework doesn't work under Cygwin.
