### PR TITLE
adding main field

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
 	"scripts": {
 		"postinstall": "node ./node/postinstall.js"
 	},
+	"main": "cli.js",
 	"bin": {
 		"jsdoc": "./jsdoc.js"
 	},


### PR DESCRIPTION
- main field is necessary to allow requiring the module in node.js

As an example this currently fails even with jsdoc installed:

``` js
var jsdoc = require('jsdoc');
// => { [Error: Cannot find module 'jsdoc'] code: 'MODULE_NOT_FOUND' }
```

After adding the main field that issue is resolved.
