### PR TITLE
Add "Mixins" to module view

### DIFF
--- a/templates/default/tmpl/container.tmpl
+++ b/templates/default/tmpl/container.tmpl
@@ -82,6 +82,18 @@
         <?js }); ?></dl>
     <?js } ?>
 
+     <?js
+        var mixins = self.find({kind: 'mixin', memberof: doc.longname});
+        if (doc.kind !== 'globalobj' && mixins && mixins.length) {
+    ?>
+        <h3 class="subsection-title">Mixins</h3>
+
+        <dl><?js mixins.forEach(function(m) { ?>
+            <dt><?js= self.linkto(m.longname, m.name) ?></dt>
+            <dd><?js if (m.summary) { ?><?js= m.summary ?><?js } ?></dd>
+        <?js }); ?></dl>
+    <?js } ?>
+
     <?js
         var namespaces = self.find({kind: 'namespace', memberof: doc.longname});
         if (doc.kind !== 'globalobj' && namespaces && namespaces.length) {


### PR DESCRIPTION
The default template does not enumerate a module's member mixins.  I can publish a third party template to include mixins if this was a design decision, but it smells like an oversight.
