### PR TITLE
use os tempdir for temp file creation

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -246,6 +246,7 @@ function createTempDir() {
     var fs = require('jsdoc/fs');
     var path = require('jsdoc/path');
     var wrench = require('wrench');
+    var os = require('os');
 
     var isRhino;
     var tempDirname;
@@ -258,7 +259,7 @@ function createTempDir() {
 
     isRhino = require('jsdoc/util/runtime').isRhino();
     tempDirname = 'tmp-' + Date.now() + '-' + getRandomId();
-    tempPath = path.join(env.dirname, tempDirname);
+    tempPath = path.join(os.tempdir(), tempDirname);
 
     try {
         fs.mkdirSync(tempPath);


### PR DESCRIPTION
Create temp file in system temp dir to enable non root user to use jsdoc
(tested on linux debian)
The only restriction so far I see when jsdoc is globally installed to use jsdoc as non root user is the creation of tmp files in the installation directory. To prevent this from throwing an access denied error try to use the os tempdir for temporary created files.
