### PR TITLE
Allow prettify to work on inline markdown code samples.

### DIFF
--- a/lib/jsdoc/util/markdown.js
+++ b/lib/jsdoc/util/markdown.js
@@ -93,7 +93,7 @@ function getParseFunction(parserName, conf) {
         };
         // Allow prettyprint to work on inline code samples
         markedRenderer.code = function(code, language) {
-          return '<pre class="prettyprint source">'+code+'</pre>';
+          return '<pre class="prettyprint source"><code>'+code+'</code></pre>';
         };
 
         parserFunction = function(source) {


### PR DESCRIPTION
Small change to replace marked's default of `<pre><code>` with `<pre class="prettyprint source">`, which results in nice looking inline code examples.
