### PR TITLE
Pass `nameIsLongname` function via RegExp.escape

### DIFF
--- a/lib/jsdoc/name.js
+++ b/lib/jsdoc/name.js
@@ -71,7 +71,7 @@ var REGEXP_LEADING_SCOPE = new RegExp('^(' + REGEXP_SCOPE_PUNC + ')');
 var REGEXP_TRAILING_SCOPE = new RegExp('(' + REGEXP_SCOPE_PUNC + ')$');
 
 function nameIsLongname(name, memberof) {
-    var regexp = new RegExp('^' + memberof + REGEXP_SCOPE_PUNC);
+    var regexp = new RegExp('^' + RegExp.escape(memberof) + REGEXP_SCOPE_PUNC);
 
     return regexp.test(name);
 }
@@ -185,7 +185,7 @@ exports.resolve = function(doclet) {
 
 // TODO: also used by jsdoc/src/handlers; extract into a utility module
 RegExp.escape = RegExp.escape || function(str) {
-    var specials = new RegExp('[.*+?|()\\[\\]{}\\\\]', 'g'); // .*+?|()[]{}\
+    var specials = new RegExp('[\\-\\[\\]{}()*+?.,\\\\\\^$|#\\s]', 'g'); // .*+?|()[]{}\
     return str.replace(specials, '\\$&');
 };
 


### PR DESCRIPTION
Member function containing regular expression tokens causes jsDoc to break. Passing them via `RegExp.escape` causes these tokens to get escaped and hence generate a valid regular expression. 

Also updated `RegExp.escape` function's regular expression to be exhaustive enough for all RegExp tokens.

Error Stack Trace using `3.3.0-alpha9 (Sat, 28 Jun 2014 15:26:03 GMT)`:

``` terminal
/usr/local/lib/node_modules/jsdoc/lib/jsdoc/name.js:39
    var regexp = new RegExp('^' + memberof + REGEXP_SCOPE_PUNC);
                 ^
SyntaxError: Invalid regular expression: /^FusionCharts#internal\([~#.])/: Unmatched ')'
    at new RegExp (<anonymous>)
    at nameIsLongname (/usr/local/lib/node_modules/jsdoc/lib/jsdoc/name.js:39:18)
    at Object.exports.resolve (/usr/local/lib/node_modules/jsdoc/lib/jsdoc/name.js:78:21)
    at Doclet.postProcess (/usr/local/lib/node_modules/jsdoc/lib/jsdoc/doclet.js:171:20)
    at null.<anonymous> (/usr/local/lib/node_modules/jsdoc/lib/jsdoc/src/handlers.js:214:19)
    at EventEmitter.emit (events.js:98:17)
    at Visitor.visitNodeComments (/usr/local/lib/node_modules/jsdoc/lib/jsdoc/src/visitor.js:249:20)
    at Visitor.visit (/usr/local/lib/node_modules/jsdoc/lib/jsdoc/src/visitor.js:177:27)
    at Walker.recurse (/usr/local/lib/node_modules/jsdoc/lib/jsdoc/src/walker.js:533:27)
    at Parser._parseSourceCode (/usr/local/lib/node_modules/jsdoc/lib/jsdoc/src/parser.js:248:26)
```

PS: Sorry for not-so-descriptive PR that I had to do in a hurry.
