### PR TITLE
Optionally scan tutorials directory recursively

### DIFF
--- a/lib/jsdoc/opts/args.js
+++ b/lib/jsdoc/opts/args.js
@@ -73,22 +73,21 @@ function parseQuery(str) {
     return result;
 }
 
-argParser.addOption('t', 'template',    	true,  'The path to the template to use. Default: path/to/jsdoc/templates/default');
-argParser.addOption('c', 'configure',   	true,  'The path to the configuration file. Default: path/to/jsdoc/conf.json');
-argParser.addOption('e', 'encoding',    	true,  'Assume this encoding when reading all source files. Default: utf8');
-argParser.addOption('T', 'test',        	false, 'Run all tests and quit.');
-argParser.addOption('d', 'destination', 	true,  'The path to the output folder. Use "console" to dump data to the console. Default: ./out/');
-argParser.addOption('p', 'private',     	false, 'Display symbols marked with the @private tag. Default: false');
-argParser.addOption('r', 'recurse',     	false, 'Recurse into subdirectories when scanning for source code files.');
-argParser.addOption('h', 'help',        	false, 'Print this message and quit.');
-argParser.addOption('X', 'explain',     	false, 'Dump all found doclet internals to console and quit.');
-argParser.addOption('q', 'query',       	true,  'A query string to parse and store in env.opts.query. Example: foo=bar&baz=true', false, parseQuery);
-argParser.addOption('u', 'tutorials',   	true,  'Directory in which JSDoc should search for tutorials.');
-argParser.addOption('U', 'fulltutorials',	false, 'Scan for tutorials recursively.');
-argParser.addOption('v', 'version',     	false, 'Display the version number and quit.');
-argParser.addOption('',  'debug',       	false, 'Log information for debugging JSDoc. On Rhino, launches the debugger when passed as the first option.');
-argParser.addOption('',  'verbose',     	false, 'Log detailed information to the console as JSDoc runs.');
-argParser.addOption('',  'pedantic',    	false, 'Treat errors as fatal errors, and treat warnings as errors. Default: false');
+argParser.addOption('t', 'template',    true,  'The path to the template to use. Default: path/to/jsdoc/templates/default');
+argParser.addOption('c', 'configure',   true,  'The path to the configuration file. Default: path/to/jsdoc/conf.json');
+argParser.addOption('e', 'encoding',    true,  'Assume this encoding when reading all source files. Default: utf8');
+argParser.addOption('T', 'test',        false, 'Run all tests and quit.');
+argParser.addOption('d', 'destination', true,  'The path to the output folder. Use "console" to dump data to the console. Default: ./out/');
+argParser.addOption('p', 'private',     false, 'Display symbols marked with the @private tag. Default: false');
+argParser.addOption('r', 'recurse',     false, 'Recurse into subdirectories when scanning for source code files.');
+argParser.addOption('h', 'help',       	false, 'Print this message and quit.');
+argParser.addOption('X', 'explain',    	false, 'Dump all found doclet internals to console and quit.');
+argParser.addOption('q', 'query',      	true,  'A query string to parse and store in env.opts.query. Example: foo=bar&baz=true', false, parseQuery);
+argParser.addOption('u', 'tutorials',   true,  'Directory in which JSDoc should search for tutorials.');
+argParser.addOption('v', 'version',    	false, 'Display the version number and quit.');
+argParser.addOption('',  'debug',      	false, 'Log information for debugging JSDoc. On Rhino, launches the debugger when passed as the first option.');
+argParser.addOption('',  'verbose',    	false, 'Log detailed information to the console as JSDoc runs.');
+argParser.addOption('',  'pedantic',   	false, 'Treat errors as fatal errors, and treat warnings as errors. Default: false');
 
 // Options specific to tests
 argParser.addOption(null, 'match',      true,  'Only run tests containing <value>.', true);

--- a/lib/jsdoc/tutorial/resolver.js
+++ b/lib/jsdoc/tutorial/resolver.js
@@ -107,13 +107,12 @@ exports.root.getByName = function(name) {
     @param {string} _path - Tutorials directory.
  */
 exports.load = function(_path) {
-    var recursive = env.opts.fulltutorials ? 5 : 1;
     var match,
         type,
         name,
         content,
         current,
-        files = fs.ls(_path, recursive);
+        files = fs.ls(_path, 5);
 
     // tutorials handling
     files.forEach(function(file) {

--- a/test/specs/jsdoc/tutorial/resolver.js
+++ b/test/specs/jsdoc/tutorial/resolver.js
@@ -127,7 +127,7 @@ describe("jsdoc/tutorial/resolver", function() {
         resolver.resolve();
         it("hierarchy is resolved properly no matter how the children property is defined", function() {
             // root has child 'test'
-            expect(resolver.root.children.length).toBe(3);
+            expect(resolver.root.children.length).toBe(4);
             expect(resolver.root.children).toContain(test);
             expect(resolver.root.children).toContain(constr);
             expect(test.parent).toBe(resolver.root);

--- a/test/tutorials/tutorials/recursive/test_recursive.md
+++ b/test/tutorials/tutorials/recursive/test_recursive.md
@@ -1,0 +1,1 @@
+# test_recursive.md


### PR DESCRIPTION
I do not want to have a directory of tutorials. I need to have the
tutorials distributed throughout the project. I have one in each
"package" folders. My project have multiples "packages" each one maintained by different developers. These packages have a tutorial "{package_name}-tutorial.md" at its own folder. Then in the documentation I need to refer to these tutorials.
So now using " -u ./ -U" jsdoc scan recursively the root folder to index tutorials.
(I know that if these tutorials have the same name only the first one will be used)
