### PR TITLE
Add markdown support for @throws tag

### DIFF
--- a/plugins/markdown.js
+++ b/plugins/markdown.js
@@ -8,7 +8,7 @@
 'use strict';
 
 var conf = env.conf.markdown;
-var defaultTags = [ 'classdesc', 'description', 'params', 'properties', 'returns', 'see'];
+var defaultTags = [ 'classdesc', 'description', 'params', 'properties', 'returns', 'see', 'exceptions' ];
 var hasOwnProp = Object.prototype.hasOwnProperty;
 var parse = require('jsdoc/util/markdown').getParser();
 var tags = [];


### PR DESCRIPTION
I don't see any reason markdown plugin not support `@throws` tag
