### PR TITLE
Don't create filenames beginning with underscore

### DIFF
--- a/lib/jsdoc/util/templateHelper.js
+++ b/lib/jsdoc/util/templateHelper.js
@@ -42,6 +42,12 @@ function makeUniqueFilename(filename, str) {
     var key = filename.toLowerCase();
     var nonUnique = true;
 
+    // don't allow filenames to begin with an underscore
+    if (!filename.length || filename[0] === '_') {
+      filename = 'X' + filename;
+      key = filename.toLowerCase();
+    }
+
     // append enough underscores to make the filename unique
     while (nonUnique) {
         if ( hasOwnProp.call(files, key) ) {


### PR DESCRIPTION
A lot of related software (most notably github.io and the default configuration of jsdoc itself) ignores files with names that begin with an underscore, but the makeUniqueFilename() creates such filenames when the incoming filename is blank. This patch modifies makeUniqueFilename() to insert the ASCII letter "X" before empty filenames or filenames that begin with an underscore.
