### PR TITLE
Attributes optional, nullable, repeatable generate invalid html in description for properties and params

### DIFF
--- a/templates/default/tmpl/params.tmpl
+++ b/templates/default/tmpl/params.tmpl
@@ -80,15 +80,15 @@
             <?js if (params.hasAttributes) {?>
                 <td class="attributes">
                 <?js if (param.optional) { ?>
-                    &lt;optional><br>
+                    &lt;optional&gt;<br>
                 <?js } ?>
 
                 <?js if (param.nullable) { ?>
-                    &lt;nullable><br>
+                    &lt;nullable&gt;<br>
                 <?js } ?>
 
                 <?js if (param.variable) { ?>
-                    &lt;repeatable><br>
+                    &lt;repeatable&gt;<br>
                 <?js } ?>
                 </td>
             <?js } ?>

--- a/templates/default/tmpl/properties.tmpl
+++ b/templates/default/tmpl/properties.tmpl
@@ -81,11 +81,11 @@
             <?js if (props.hasAttributes) {?>
                 <td class="attributes">
                 <?js if (prop.optional) { ?>
-                    &lt;optional><br>
+                    &lt;optional&gt;<br>
                 <?js } ?>
 
                 <?js if (prop.nullable) { ?>
-                    &lt;nullable><br>
+                    &lt;nullable&gt;<br>
                 <?js } ?>
                 </td>
             <?js } ?>


### PR DESCRIPTION
For example "&lt;optional>" should be "&lt;optional&gt;"
