### PR TITLE
Falling back to regex solution for default value when value is malformed

### DIFF
--- a/lib/jsdoc/name.js
+++ b/lib/jsdoc/name.js
@@ -408,8 +408,12 @@ exports.splitName = function(nameDesc) {
     // dash as a separator
 
     // optional values get special treatment
+    var result = null;
     if (nameDesc[0] === '[') {
-        return splitNameMatchingBrackets(nameDesc);
+        result = splitNameMatchingBrackets(nameDesc);
+        if (result !== null) {
+            return result;
+        }
     }
 
     nameDesc.match(REGEXP_NAME_DESCRIPTION);

--- a/test/specs/jsdoc/name.js
+++ b/test/specs/jsdoc/name.js
@@ -264,6 +264,24 @@ describe('jsdoc/name', function() {
             expect(parts.name).toBe('[path=["Unmatched begin: ["]]');
             expect(parts.description).toBe('Path split into components');
         });
+
+        it('should fail gracefully when the default value has an unmatched bracket', function() {
+            var startName = '[path=["home", "user"] - Path split into components'
+            var parts = jsdoc.name.splitName(startName);
+
+            expect(parts).not.toBe(null);
+            expect(parts.name).toBe('[path=["home", "user"]');
+            expect(parts.description).toBe('Path split into components');
+        });
+
+        it('should fail gracefully when the default value has an unmatched quote', function() {
+            var startName = '[path=["home", "user] - Path split into components'
+            var parts = jsdoc.name.splitName(startName);
+
+            expect(parts).not.toBe(null);
+            expect(parts.name).toBe('[path=["home", "user]');
+            expect(parts.description).toBe('Path split into components');
+        });
     });
 
     describe('resolve', function() {


### PR DESCRIPTION
This keeps `splitName()` from returning `null` when the default-value validator fails. Instead of returning `null` we fall back to the regex solution. This can generate odd output, but it's no worse than before we were special-casing default values anyway.

Added the following tests which fail without the patch and pass with it:
    1) should fail gracefully when the default value has an unmatched bracket
    2) should fail gracefully when the default value has an unmatched quote
