### PR TITLE
Index usability improvements2 (PR #813) - fix

### DIFF
--- a/templates/default/publish.js
+++ b/templates/default/publish.js
@@ -295,7 +295,10 @@ function buildMemberNav(items, itemHeading, itemsSeen, linktoFn) {
         var itemsNav = '';
 
         items.forEach(function(item) {
-            if ( !hasOwnProp.call(itemsSeen, item.longname) ) {
+            if ( !hasOwnProp.call(item, 'longname') ) {
+                itemsNav += '<li>' + linktoFn('', item.name) + '</li>';
+            }
+            else if ( !hasOwnProp.call(itemsSeen, item.longname) ) {
                 itemsNav += '<li>' + linktoFn(item.longname, item.name.replace(/^module:/, '')) + '</li>';
                 itemsSeen[item.longname] = true;
             }


### PR DESCRIPTION
Fixed listing of tutorials in the navigation. There was displayed only one tutorial. Its name without a link.
