### PR TITLE
add filename stripping to prefixReducer

### DIFF
--- a/lib/jsdoc/path.js
+++ b/lib/jsdoc/path.js
@@ -17,6 +17,10 @@ function prefixReducer(previousPath, current) {
         return currentPath;
     }
 
+    if ( path.extname(current) ) {
+        current = path.dirname(current);
+    }
+
     currentPath = path.resolve(env.pwd, current).split(path.sep) || [];
 
     if (previousPath && currentPath.length) {


### PR DESCRIPTION
The filename was not being stripped when the commonPrefix method received an array of paths, which meant that the generated documentation would end up showing a full path referencing the source file/line in which the doclet could be found.

This could be a result of the JaguarJS templates, and not specifically an issue with JSDoc, but this change fixed the issue on my end.
