### PR TITLE
Add addEventFirers function

### DIFF
--- a/lib/jsdoc/util/templateHelper.js
+++ b/lib/jsdoc/util/templateHelper.js
@@ -805,6 +805,42 @@ exports.getAncestorLinks = function(data, doclet, cssClass) {
 
 /**
  * Iterates through all the doclets in `data`, ensuring that if a method
+ * @fires to an event, then that event has a 'firers' array with the
+ * longname of the firer in it.
+ *
+ * @param {TAFFY} data - The TaffyDB database to search.
+ */
+exports.addEventFirers = function(data) {
+    // TODO: do this on the *pruned* data
+    // find all doclets that @fire to something.
+    var firers = find(data, function () { return this.fires && this.fires.length; });
+
+    if (!firers.length) {
+        return;
+    }
+
+    var doc,
+        l,
+        _events = {}; // just a cache to prevent me doing so many lookups
+
+    firers.forEach(function (firer) {
+        l = firer.fires;
+        l.forEach(function (eventLongname) {
+            doc = _events[eventLongname] || find(data, {longname: eventLongname, kind: 'event'})[0];
+            if (doc) {
+                if (!doc.firers) {
+                    doc.firers = [firer.longname];
+                } else {
+                    doc.firers.push(firer.longname);
+                }
+                _events[eventLongname] = _events[eventLongname] || doc;
+            }
+        });
+    });
+};
+
+/**
+ * Iterates through all the doclets in `data`, ensuring that if a method
  * @listens to an event, then that event has a 'listeners' array with the
  * longname of the listener in it.
  *

--- a/test/specs/jsdoc/util/templateHelper.js
+++ b/test/specs/jsdoc/util/templateHelper.js
@@ -106,6 +106,11 @@ describe("jsdoc/util/templateHelper", function() {
         expect(typeof helper.getAncestorLinks).toBe("function");
     });
 
+    it("should export a 'addEventFirers' function", function() {
+        expect(helper.addEventFirers).toBeDefined();
+        expect(typeof helper.addEventFirers).toBe("function");
+    });
+
     it("should export a 'addEventListeners' function", function() {
         expect(helper.addEventListeners).toBeDefined();
         expect(typeof helper.addEventListeners).toBe("function");
@@ -971,6 +976,10 @@ describe("jsdoc/util/templateHelper", function() {
             delete helper.longnameToUrl['module:mafia/gangs'];
             delete helper.longnameToUrl['module:mafia/gangs.Sharks~Henchman'];
         });
+    });
+
+    describe("addEventFirers", function() {
+        // TODO
     });
 
     describe("addEventListeners", function() {

--- a/test/specs/jsdoc/util/templateHelper.js
+++ b/test/specs/jsdoc/util/templateHelper.js
@@ -979,7 +979,26 @@ describe("jsdoc/util/templateHelper", function() {
     });
 
     describe("addEventFirers", function() {
-        // TODO
+        var doclets = (taffy(doop(jasmine.getDocSetFromFile('test/fixtures/eventfirestag.js').doclets))),
+            ev = helper.find(doclets, {longname: 'Hurl#event:snowball'})[0],
+            ev2 = helper.find(doclets, {longname: 'Hurl#event:footballMatch'})[0];
+
+        helper.addEventFirers(doclets);
+
+        it("adds a 'firers' array to events with the longnames of the firers", function() {
+            expect(Array.isArray(ev.firers)).toBe(true);
+            expect(Array.isArray(ev2.firers)).toBe(true);
+
+            expect(ev.firers.length).toBe(1);
+            expect(ev.firers).toContain('Hurl#snowball');
+
+            expect(ev2.firers.length).toBe(1);
+            expect(ev2.firers).toContain('Hurl#footballMatch');
+        });
+
+        it("does not make spurious doclets if something @fires to a non-existent symbol", function() {
+            expect(helper.find(doclets, {longname: 'Hurl#event:brick'}).length).toBe(0);
+        });
     });
 
     describe("addEventListeners", function() {


### PR DESCRIPTION
Use addEventListeners function as template for an addEventFirers function, which will ultimately permit custom templates that list all of the methods that fire a certain event. Essentially, I want to see all of the firers (emitters) of my event, not just the listeners, so this would actually make that possible.
