### PR TITLE
Add specs plugin.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ out/
 
 # Dotfile detritus
 .DS_Store
+
+# IDE files
+.idea

--- a/plugins/specs.js
+++ b/plugins/specs.js
@@ -1,0 +1,50 @@
+/**
+ * @overview Generate specification list from source code inline comments.
+ * @module plugins/specs
+ * @author Uros Jarc <https://github.com/urosjarc>
+ */
+'use strict';
+
+var path = require('path');
+var fs = require('fs');
+
+exports.handlers = {
+    newDoclet: function (e) {
+        var meta = e.doclet.meta;
+        var description = e.doclet.description;
+
+        var sourceString = '';
+        var sourceLines = [];
+        var commentsArr = [];
+
+        if (typeof description === 'string' && meta.path && meta.filename) {
+            // Set sourceString
+            var fileContent = fs.readFileSync(
+                path.join(meta.path || '.', meta.filename),
+                'utf-8'
+            );
+
+            // Set sourceLines
+            for (var i = meta.range[0]; i < meta.range[1]; i++) {
+                sourceString += fileContent[i];
+            }
+            sourceLines = sourceString.split('\n');
+
+            // Set commentsArr
+            for (var j in sourceLines) {
+                if (sourceLines[j].indexOf('//') !== -1) {
+                    commentsArr.push(sourceLines[j].split('//')[1]);
+                }
+            }
+
+            // Set new description if commentsArr is full
+            if (commentsArr.length > 0) {
+                e.doclet.description += '\n<b>Specs:</b>\n<ol>\n';
+                for (var k = 0; k < commentsArr.length; k++) {
+                    e.doclet.description += '<li>' + commentsArr[k] + '</li>\n';
+                }
+                e.doclet.description += '</ol>';
+            }
+        }
+    }
+};

--- a/plugins/test/fixtures/specs.js
+++ b/plugins/test/fixtures/specs.js
@@ -1,0 +1,52 @@
+'use strict';
+
+/**
+ * spec
+ * @module spec
+ */
+
+//Line
+
+/**
+ * fun0
+ */
+function fun0() {
+    //Line0
+    //Line1
+
+    //Line2
+}
+
+/**
+ * variable0
+ * @type {string}
+ */
+var variable0 = 'var0'; //Line3
+
+/**
+ * Klass
+ * @constructor
+ */
+function Klass() {
+
+    //Line7
+
+    /**
+     * variable1
+     * @type {string}
+     */
+    this.variable1 = 'var1'; //Line4
+
+    //Line8
+}
+
+/**
+ * fun1
+ */
+Klass.prototype.fun1 = function () {
+    //Line5
+    //Line6
+};
+
+
+

--- a/plugins/test/specs/specs.js
+++ b/plugins/test/specs/specs.js
@@ -1,0 +1,98 @@
+'use strict';
+
+var env = require('jsdoc/env');
+var path = require('jsdoc/path');
+
+describe('specs', function () {
+    var pluginPath = 'plugins/specs';
+    var pluginPathResolved = path.join(env.dirname, pluginPath);
+    var plugin = require(pluginPathResolved);
+    var docSet = jasmine.getDocSetFromFile('plugins/test/fixtures/specs.js');
+
+    it('should export handlers', function () {
+        expect(plugin.handlers).toBeDefined();
+        expect(typeof plugin.handlers).toBe('object');
+    });
+
+    it('should export a newDoclet handler', function () {
+        expect(plugin.handlers.newDoclet).toBeDefined();
+        expect(typeof plugin.handlers.newDoclet).toBe('function');
+    });
+
+    describe('#handler.doclet', function () {
+
+        var fixturesPath = path.join(env.dirname, 'plugins/test/fixtures');
+        var doclet = plugin.handlers.newDoclet;
+        var docs = {
+            spec: {doclet: docSet.getByLongname('module:spec')[0]},
+            fun0: {doclet: docSet.getByLongname('module:spec~fun0')[0]},
+            variable0: {doclet: docSet.getByLongname('module:spec~variable0')[0]},
+            Klass: {doclet: docSet.getByLongname('module:spec~Klass')[0]},
+            variable1: {doclet: docSet.getByLongname('module:spec~Klass#variable1')[0]},
+            fun1: {doclet: docSet.getByLongname('module:spec~Klass#fun1')[0]}
+        };
+        for (var i in docs) {
+            docs[i].doclet.meta.filename = 'specs.js';
+            docs[i].doclet.meta.path = path.join(fixturesPath);
+        }
+
+        it('should not spec module', function () {
+            expect(docs.spec.doclet.description).toEqual('spec');
+            doclet(docs.spec);
+            expect(docs.spec.doclet.description).toEqual('spec');
+        });
+
+        it('should spec fun0', function () {
+            expect(docs.fun0.doclet.description).toEqual('fun0');
+            doclet(docs.fun0);
+            expect(docs.fun0.doclet.description).toEqual([
+                'fun0',
+                '<b>Specs:</b>',
+                '<ol>',
+                '<li>Line0</li>',
+                '<li>Line1</li>',
+                '<li>Line2</li>',
+                '</ol>'
+            ].join('\n'));
+        });
+
+        it('should not spec variable0', function () {
+            expect(docs.variable0.doclet.description).toEqual('variable0');
+            doclet(docs.variable0);
+            expect(docs.variable0.doclet.description).toEqual('variable0');
+        });
+
+        it('should spec Klass', function () {
+            expect(docs.Klass.doclet.description).toEqual('Klass');
+            doclet(docs.Klass);
+            expect(docs.Klass.doclet.description).toEqual([
+                'Klass',
+                '<b>Specs:</b>',
+                '<ol>',
+                '<li>Line7</li>',
+                '<li>Line4</li>',
+                '<li>Line8</li>',
+                '</ol>'
+            ].join('\n'));
+        });
+
+        it('should not spec variable1', function () {
+            expect(docs.variable1.doclet.description).toEqual('variable1');
+            doclet(docs.variable1);
+            expect(docs.variable1.doclet.description).toEqual('variable1');
+        });
+
+        it('should spec fun1', function () {
+            expect(docs.fun1.doclet.description).toEqual('fun1');
+            doclet(docs.fun1);
+            expect(docs.fun1.doclet.description).toEqual([
+                'fun1',
+                '<b>Specs:</b>',
+                '<ol>',
+                '<li>Line5</li>',
+                '<li>Line6</li>',
+                '</ol>'
+            ].join('\n'));
+        });
+    });
+});


### PR DESCRIPTION
I wanted to add some kind of [docco](https://jashkenas.github.io/docco/) parrsing support.
Plugin spec should parse the source file and parse inline comments accoring to `doclet.meta.range` array,
and add ordered list of inline comment text in that list.

For example this code:

```
/**
 * Constructor. Setup options and arguments
 * for generator to use.
 */
exports.constructor = function () {
    //Setup arguments
    generator.Base.apply(this, arguments);
    //Setup options
    this.option('debug', {
        desc: 'Debug generator to ./generator.debug file',
        type: Boolean,
        default: false
    });
};
```

Will be displayed like this:
[![2016-09-27-171933_699x1031_scrot.png](https://s21.postimg.org/b4dnfqwhj/2016_09_27_171933_699x1031_scrot.png)](https://postimg.org/image/65q517soj/)

For more informations see added tests and fixtures example.
