### PR TITLE
Document execution via npx

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ To generate documentation for the file `yourJavaScriptFile.js`:
 
     ./node_modules/.bin/jsdoc yourJavaScriptFile.js
 
+For npm 5.2.0 and above you can use the `npx` command:
+
+    npx jsdoc yourJavaScriptFile.js
+
 Or if you installed JSDoc globally, simply run the `jsdoc` command:
 
     jsdoc yourJavaScriptFile.js


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Deprecations?    | no
| Tests added?     | no
| Fixed issues     | 
| License          | Apache-2.0

<!-- Describe your changes below in as much detail as possible. -->
In July 2017 npm 5.2.0 was released which added the `npx` command to execute local scripts ([blog](http://blog.npmjs.org/post/162869356040/introducing-npx-an-npm-package-runner), [release](https://github.com/npm/npm/releases/tag/v5.2.0)).

This change adds a note that describes running a local jsdoc via `npx`.