### PR TITLE
Sort tutorials

### DIFF
--- a/lib/jsdoc/tutorial/resolver.js
+++ b/lib/jsdoc/tutorial/resolver.js
@@ -64,6 +64,7 @@ function addTutorialConf(name, meta) {
             logger.warn(`Metadata for the tutorial ${name} is defined more than once. Only the first definition will be used.`);
         } else {
             conf[name] = meta;
+            meta.autoindex = Object.keys(conf).length;
         }
     } else {
         // keys are tutorial names, values are `Tutorial` instances
@@ -164,6 +165,11 @@ exports.resolve = () => {
         // set title
         if (item.title) {
             current.title = item.title;
+        }
+
+        // set autoindex
+        if (item.autoindex) {
+            current.autoindex = item.autoindex;
         }
 
         // add children

--- a/templates/default/publish.js
+++ b/templates/default/publish.js
@@ -646,6 +646,18 @@ exports.publish = (taffyData, opts, tutorials) => {
     members = helper.getMembers(data);
     members.tutorials = tutorials.children;
 
+    if (conf.default.sortTutorialsByConfigOrder) {
+        members.tutorials.sort((a, b) => {
+            if (a.autoindex !== undefined && b.autoindex !== undefined) {
+                return a.autoindex - b.autoindex;
+            } else if (a.autoindex !== undefined) {
+                return -1;
+            } else if (b.autoindex !== undefined) {
+                return 1;
+            }
+        });
+    }
+
     // output pretty-printed source files by default
     outputSourceFiles = conf.default && conf.default.outputSourceFiles !== false;
 

--- a/test/specs/jsdoc/tutorial/resolver.js
+++ b/test/specs/jsdoc/tutorial/resolver.js
@@ -206,6 +206,16 @@ describe('jsdoc/tutorial/resolver', () => {
             expect(test.title).toBe('Test tutorial');
         });
 
+        it('tutorials without configuration files have no autoindex', () => {
+            // test6.xml didn't have metadata
+            expect(test6.autoindex).toBe(undefined);
+        });
+
+        it('tutorials with configuration files have an autoindex attribute with config order', () => {
+            // test2, test3 were described in that order in multiple.json
+            expect(test2.autoindex).toBeLessThan(test3.autoindex);
+        });
+
         it('multiple tutorials can appear in a configuration file', () => {
             expect(test2.title).toBe('Test 2');
             expect(test3.title).toBe('Test 3');


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Deprecations?    | no
| Tests added?     | yes
| Fixed issues     | #1028
| License          | Apache-2.0

Tutorial metadata now has an autoindex field, which is based on the
order in which the tutorials appear in the json config file.

Templates can choose to sort based on this if they wish.

This adds the "sortTutorialsByConfigOrder" option to the default
template to sort based on this new field.

Issue #1028