### PR TITLE
add typedef output to haruki

### DIFF
--- a/templates/haruki/publish.js
+++ b/templates/haruki/publish.js
@@ -111,7 +111,6 @@ function graft(parentNode, childNodes, parentLongname) {
                 'type': element.type? (element.type.length === 1? element.type[0] : element.type) : ''
             });
         }
-
         else if (element.kind === 'event') {
             if (!parentNode.events) {
                 parentNode.events = [];
@@ -197,7 +196,64 @@ function graft(parentNode, childNodes, parentLongname) {
             }
 
             graft(thisClass, childNodes, element.longname);
-       }
+        }
+        else if (element.kind === 'typedef') {
+            if (!parentNode.typedefs) {
+                parentNode.typedefs = [];
+            }
+
+            thisTypedef = {
+                'name': element.name,
+                'access': element.access || '',
+                'virtual': Boolean(element.virtual),
+                'description': element.description || '',
+            };
+            parentNode.typedefs.push(thisTypedef);
+
+            if (element.returns) {
+                thisEvent.returns = {
+                    'type': element.returns.type ? (element.returns.type.names.length === 1 ? element.returns.type.names[0] : element.returns.type.names) : '',
+                    'description': element.returns.description || ''
+                };
+            }
+
+            if (element.examples) {
+                thisTypedef.examples = [];
+                for (i = 0, len = element.examples.length; i < len; i++) {
+                    thisTypedef.examples.push(element.examples[i]);
+                }
+            }
+
+            if (element.params) {
+                thisTypedef.parameters = [];
+                for (i = 0, len = element.params.length; i < len; i++) {
+                    thisTypedef.parameters.push({
+                        'name': element.params[i].name,
+                        'type': element.params[i].type? (element.params[i].type.names.length === 1? element.params[i].type.names[0] : element.params[i].type.names) : '',
+                        'description': element.params[i].description || '',
+                        'default': hasOwnProp.call(element.params[i], 'defaultvalue') ? element.params[i].defaultvalue : '',
+                        'optional': typeof element.params[i].optional === 'boolean'? element.params[i].optional : '',
+                        'nullable': typeof element.params[i].nullable === 'boolean'? element.params[i].nullable : ''
+                    });
+                }
+            }
+
+            if (element.properties) {
+                thisTypedef.properties = [];
+                for (i = 0, len = element.properties.length; i < len; i++) {
+                    thisTypedef.properties.push({
+                        'name': element.properties[i].name,
+                        'type': element.properties[i].type? (element.properties[i].type.names.length === 1? element.properties[i].type.names[0] : element.properties[i].type.names) : '',
+                        'description': element.properties[i].description || '',
+                        'default': hasOwnProp.call(element.properties[i], 'defaultvalue') ? element.properties[i].defaultvalue : '',
+                        'optional': typeof element.properties[i].optional === 'boolean'? element.properties[i].optional : '',
+                        'nullable': typeof element.properties[i].nullable === 'boolean'? element.properties[i].nullable : ''
+                    });
+                }
+            }
+
+            graft(thisTypedef, childNodes, element.longname);
+        }
     });
 }
 


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Deprecations?    | no
| Tests added?     | no
| Fixed issues     | #1508
| License          | Apache-2.0

Hi! Great project, it's very useful.

I was previously using jsdoc to generate html docs. However now I am working on cross-platform docs for my project. This requires some intermediate representation of the docs from each generator, so that these intermediate bits can be massaged into markdown, which is then turned into html with mkdocs.

I was glad to find I could just keep my existing js docstrings by using the haruki template. However, I ran into a snag. At first I was confused to find that many of my docstrings weren't present. Then I realized that haruki omits typedefs entirely. Since these typedef/callback annotations comprise probably 50% of my docs, this is a pretty big omission.

So now I offer an output for typedefs in the haruki template. This is working perfectly for me from what I can tell, and now it looks like my docs are all present. I offer this PR in hopes it may help someone in a similar predicament.
