### PR TITLE
fix: caculate the more proper value for object expression

### DIFF
--- a/lib/jsdoc/src/astnode.js
+++ b/lib/jsdoc/src/astnode.js
@@ -266,14 +266,15 @@ var nodeToValue = exports.nodeToValue = function(node) {
                     return;
                 }
 
-                key = prop.key.name;
+                // key may be string quoted and unable to be identifier
+                key = prop.key.type === Syntax.Identifier ? prop.key.name : prop.key.value;
 
                 // preserve literal values so that the JSON form shows the correct type
                 if (prop.value.type === Syntax.Literal) {
                     tempObject[key] = prop.value.value;
                 }
                 else {
-                    tempObject[key] = nodeToValue(prop);
+                    tempObject[key] = nodeToValue(prop.value);
                 }
             });
 

--- a/test/specs/jsdoc/src/astnode.js
+++ b/test/specs/jsdoc/src/astnode.js
@@ -34,6 +34,7 @@ describe('jsdoc/src/astNode', function() {
     var propertyGet = parse('var foo = { get bar() {} };').declarations[0].init.properties[0];
     var propertyInit = parse('var foo = { bar: {} };').declarations[0].init.properties[0];
     var propertySet = parse('var foo = { set bar(a) {} };').declarations[0].init.properties[0];
+    var objectExpression = parse('var foo = { test: { bar: [1], "bar-a": 12, "barb": /test/ } }').declarations[0].init.properties[0];
     var thisExpression = parse('this;').expression;
     var unaryExpression1 = parse('+1;').expression;
     var unaryExpression2 = parse('+foo;').expression;
@@ -313,6 +314,22 @@ describe('jsdoc/src/astNode', function() {
 
             expect(info.name).toBe('foo.bar');
             expect(info.type).toBe(Syntax.MemberExpression);
+        });
+
+        it('should return the correct info for a ObjectExpression', function() {
+            var info = astNode.getInfo(objectExpression);
+
+            expect(info).toBeDefined();
+
+            expect(info.node).toBeDefined();
+            expect(info.node.type).toBe(Syntax.ObjectExpression);
+
+            expect(info.type).toBe(Syntax.ObjectExpression);
+            expect(info.value).toBe(JSON.stringify({
+                bar: '[1]',
+                'bar-a': 12,
+                'barb': /test/
+            }));
         });
 
         it('should return the correct info for a computed MemberExpression', function() {


### PR DESCRIPTION
<!--
Before creating a pull request, please read our contributing guidelines and code of conduct:

https://github.com/jsdoc3/jsdoc/blob/master/CONTRIBUTING.md
https://github.com/jsdoc3/jsdoc/blob/master/CODE_OF_CONDUCT.md
-->

| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Deprecations?    | no
| Tests added?     | yes
| Fixed issues     | 
| License          | Apache-2.0

<!-- Describe your changes below in as much detail as possible. -->

Before, the parsing for `ObjectExpression` Node will generate incorrect value.

like:
```
{
  test: {
    "foo": "bar",
    "foo-a": 42
  }
}
```
the `ObjectExpression` of prop `test` will be calc as `{"undefined": 42}`,

after fixing, it will generate the correct value.