### PR TITLE
pass filter to `ls` to avoid recursing into excluded directories

### DIFF
--- a/lib/jsdoc/fs.js
+++ b/lib/jsdoc/fs.js
@@ -8,7 +8,7 @@ var fs = require('fs');
 var path = require('path');
 var mkdirp = require('mkdirp');
 
-var ls = exports.ls = function(dir, recurse, _allFiles, _path) {
+var ls = exports.ls = function(dir, recurse, filter, _allFiles, _path) {
     var file;
     var files;
     var isFile;
@@ -52,8 +52,10 @@ var ls = exports.ls = function(dir, recurse, _allFiles, _path) {
             // it's a directory
             _path.push(file);
 
-            if (_path.length - 1 < recurse) {
-                ls(_path.join('/'), recurse, _allFiles, _path);
+            var filepath = _path.join('/');
+
+            if (_path.length - 1 < recurse && (!filter || !filter.isExcluded(filepath))) {
+                ls(filepath, recurse, filter, _allFiles, _path);
             }
             _path.pop();
         }

--- a/lib/jsdoc/src/filter.js
+++ b/lib/jsdoc/src/filter.js
@@ -35,6 +35,30 @@ exports.Filter = function(opts) {
 
 /**
  * @param {string} filepath - The filepath to check.
+ * @returns {boolean} Should the given file/dir be excluded?
+ */
+exports.Filter.prototype.isExcluded = function(filepath) {
+    var excluded = false;
+
+    filepath = path.resolve(env.pwd, filepath);
+
+    if ( this.excludePattern && this.excludePattern.test(filepath) ) {
+        excluded = true;
+    }
+
+    if (this.exclude) {
+        this.exclude.forEach(function(exclude) {
+            if ( filepath.indexOf(exclude) === 0 ) {
+                excluded = true;
+            }
+        });
+    }
+
+    return excluded;
+};
+
+/**
+ * @param {string} filepath - The filepath to check.
  * @returns {boolean} Should the given file be included?
  */
 exports.Filter.prototype.isIncluded = function(filepath) {
@@ -46,17 +70,5 @@ exports.Filter.prototype.isIncluded = function(filepath) {
         included = false;
     }
 
-    if ( this.excludePattern && this.excludePattern.test(filepath) ) {
-        included = false;
-    }
-
-    if (this.exclude) {
-        this.exclude.forEach(function(exclude) {
-            if ( filepath.indexOf(exclude) === 0 ) {
-                included = false;
-            }
-        });
-    }
-
-    return included;
+    return included && !this.isExcluded(filepath);
 };

--- a/lib/jsdoc/src/scanner.js
+++ b/lib/jsdoc/src/scanner.js
@@ -48,7 +48,7 @@ exports.Scanner.prototype.scan = function(searchPaths, depth, filter) {
             filePaths.push(filepath);
         }
         else {
-            filePaths = filePaths.concat( fs.ls(filepath, depth) );
+            filePaths = filePaths.concat( fs.ls(filepath, depth, filter) );
         }
     });
 

--- a/test/specs/jsdoc/fs.js
+++ b/test/specs/jsdoc/fs.js
@@ -1,0 +1,59 @@
+'use strict';
+
+describe('jsdoc/fs', function() {
+    var fs = require('jsdoc/fs');
+    var filter = require('jsdoc/src/filter');
+    var env = require('jsdoc/env');
+    var path = require('path');
+
+    function ls() {
+        return fs.ls.apply(fs, arguments).map(function(file) {
+            return path.relative(env.pwd, file);
+        });
+    }
+
+    it('should exist', function() {
+        expect(fs).toBeDefined();
+        expect(typeof fs).toBe('object');
+    });
+
+    it('should export a ls function', function() {
+        expect(fs.ls).toBeDefined();
+        expect(typeof fs.ls).toBe('function');
+    });
+
+    describe('ls', function() {
+        it('should list files without recursing into directories', function() {
+            var files = ls(env.pwd);
+
+            files.forEach(function(file) {
+                expect(file).not.toContain(path.sep);
+            });
+        });
+
+        it('should list files and recurse into directories', function() {
+            var recurseDepth = 3;
+            var files = ls(env.pwd, recurseDepth);
+            var regExp = new RegExp(path.sep, 'g');
+
+            files.forEach(function(file) {
+                var matches = file.match(regExp);
+
+                if (matches) {
+                    expect(matches.length).toBeLessThan(recurseDepth);
+                }
+            });
+        });
+
+        it('should list files and recurse into directories using filter', function() {
+            var myFilter = new filter.Filter({
+                excludePattern: new RegExp('node_modules')
+            });
+            var files = ls(env.pwd, 10, myFilter);
+
+            files.forEach(function(file) {
+                expect(file).not.toContain('node_modules');
+            });
+        });
+    });
+});

--- a/test/specs/jsdoc/src/filter.js
+++ b/test/specs/jsdoc/src/filter.js
@@ -37,6 +37,11 @@ describe('jsdoc/src/filter', function() {
             expect(myFilter.includePattern).toBeDefined();
         });
 
+        it('should have an "isExcluded" method', function() {
+            expect(myFilter.isExcluded).toBeDefined();
+            expect(typeof myFilter.isExcluded).toBe('function');
+        });
+
         it('should have an "isIncluded" method', function() {
             expect(myFilter.isIncluded).toBeDefined();
             expect(typeof myFilter.isIncluded).toBe('function');
@@ -97,6 +102,33 @@ describe('jsdoc/src/filter', function() {
         describe( 'excludePattern', testRegExpProperty.bind(jasmine, 'excludePattern') );
 
         describe( 'includePattern', testRegExpProperty.bind(jasmine, 'includePattern') );
+
+        describe('isExcluded', function() {
+            it('should be able to use excludePattern to ignore directories', function() {
+                var files = [
+                    'yes.js',
+                    '/yes.jsdoc',
+                    'node_modules/no.js',
+                    '/dist/no.js',
+                    '.ignore'
+                ];
+
+                myFilter = new filter.Filter({
+                    includePattern: defaultIncludePattern,
+                    excludePattern: 'node_modules|dist',
+                    exclude: ['.ignore']
+                });
+
+                files = files.filter(function($) {
+                    return myFilter.isExcluded($);
+                });
+
+                expect(files.length).toEqual(3);
+                expect( files.indexOf('node_modules/no.js') ).toBeGreaterThan(-1);
+                expect( files.indexOf('/dist/no.js') ).toBeGreaterThan(-1);
+                expect( files.indexOf('.ignore') ).toBeGreaterThan(-1);
+            });
+        });
 
         describe('isIncluded', function() {
             it('should return the correct source files', function() {


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Deprecations?    | no
| Tests added?     | yes
| Fixed issues     | Performance improvements when including large directory trees, especially when there are deeply nested trees that are excluded.
| License          | Apache-2.0

* Improves performance when including a large source tree, especially
ones with `node_modules` or other huge directories.
* Adds `isExcluded` filter function that extracts the exclusion
options from `isIncluded`.
* Adds `fs` spec, including tests using filter.

In our project (54,631 directories, 384,265 files) only a small subset are files that jsdoc needs to process. Most of the time was spent in `ls` recursing and collecting all files. Before this change it would finish in 60s, after – simply by ignoring `target|dist|node_modules` – it's down to 11s.
