### PR TITLE
BUG: Fixed length check, after slpice(), `l` was wrong

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -281,7 +281,7 @@ function buildSourceList() {
 
     // source files named `package.json` or `README.md` get special treatment, unless the user
     // explicitly specified a package and/or README file
-    for (var i = 0, l = sourceFiles.length; i < l; i++) {
+    for (var i = 0; i < sourceFiles.length; i++) {
         sourceFile = sourceFiles[i];
 
         if ( !env.opts.package && /\bpackage\.json$/i.test(sourceFile) ) {


### PR DESCRIPTION
<!--
Before creating a pull request, please read our contributing guidelines and code of conduct:

https://github.com/jsdoc3/jsdoc/blob/master/CONTRIBUTING.md
https://github.com/jsdoc3/jsdoc/blob/master/CODE_OF_CONDUCT.md
-->

| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Deprecations?    | no
| Tests added?     | no
| Fixed issues     | n.a.
| License          | Apache-2.0

<!-- Describe your changes below in as much detail as possible. -->

The for() loop was setting `l` as the length of the array. Then within the array you splice() it whenever a filename gets _removed_. `l` is now the wrong length. I suggest we simply use the `sourceFiles.length` so that way it works as expected. We could also reduce `l` each time a `splice()` happens.

To test, I used a `console.log(sourceFile)` inside the loop and I have a `README.md` file in my package directory. That means a `splice()` occurs and you see an `undefined` in your console for the last `i` which is larger than `sourceFiles.length`.