### PR TITLE
Remove dependency on requizzle

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -10,10 +10,9 @@
  * @private
  */
 module.exports = (() => {
-    const app = require('jsdoc/app');
-    const env = require('jsdoc/env');
-    const logger = require('jsdoc/util/logger');
-    const stripBom = require('jsdoc/util/stripbom');
+    const app = require('./lib/jsdoc/app');
+    const env = require('./lib/jsdoc/env');
+    const logger = require('./lib/jsdoc/util/logger');
     const stripJsonComments = require('strip-json-comments');
     const Promise = require('bluebird');
 
@@ -30,12 +29,7 @@ module.exports = (() => {
 
     // TODO: docs
     cli.setVersionInfo = () => {
-        const fs = require('fs');
-        const path = require('path');
-
-        // allow this to throw--something is really wrong if we can't read our own package file
-        const info = JSON.parse( stripBom.strip(fs.readFileSync(path.join(env.dirname, 'package.json'),
-            'utf8')) );
+        const info = require('./package.json');
 
         env.version = {
             number: info.version,
@@ -48,11 +42,11 @@ module.exports = (() => {
     // TODO: docs
     cli.loadConfig = () => {
         const _ = require('underscore');
-        const args = require('jsdoc/opts/args');
-        const Config = require('jsdoc/config');
+        const args = require('./lib/jsdoc/opts/args');
+        const Config = require('./lib/jsdoc/config');
         let config;
-        const fs = require('jsdoc/fs');
-        const path = require('jsdoc/path');
+        const fs = require('./lib/jsdoc/fs');
+        const path = require('./lib/jsdoc/path');
 
         let confPath;
         let isFile;
@@ -194,7 +188,7 @@ module.exports = (() => {
     // TODO: docs
     cli.printHelp = () => {
         cli.printVersion();
-        console.log( `\n${require('jsdoc/opts/args').help()}\n` );
+        console.log( `\n${require('./lib/jsdoc/opts/args').help()}\n` );
         console.log('Visit http://usejsdoc.org for more information.');
 
         return Promise.resolve(0);
@@ -202,7 +196,7 @@ module.exports = (() => {
 
     // TODO: docs
     cli.runTests = () => {
-        const path = require('jsdoc/path');
+        const path = require('./lib/jsdoc/path');
 
         const runner = Promise.promisify(require( path.join(env.dirname, 'test/runner') ));
 
@@ -242,7 +236,7 @@ module.exports = (() => {
     };
 
     function readPackageJson(filepath) {
-        const fs = require('jsdoc/fs');
+        const fs = require('./lib/jsdoc/fs');
 
         try {
             return stripJsonComments( fs.readFileSync(filepath, 'utf8') );
@@ -255,7 +249,7 @@ module.exports = (() => {
     }
 
     function buildSourceList() {
-        const Readme = require('jsdoc/readme');
+        const Readme = require('./lib/jsdoc/readme');
 
         let packageJson;
         let readmeHtml;
@@ -298,7 +292,7 @@ module.exports = (() => {
 
     // TODO: docs
     cli.scanFiles = () => {
-        const Filter = require('jsdoc/src/filter').Filter;
+        const Filter = require('./lib/jsdoc/src/filter').Filter;
 
         let filter;
 
@@ -316,7 +310,7 @@ module.exports = (() => {
     };
 
     function resolvePluginPaths(paths) {
-        const path = require('jsdoc/path');
+        const path = require('./lib/jsdoc/path');
 
         const pluginPaths = [];
 
@@ -338,9 +332,9 @@ module.exports = (() => {
     }
 
     cli.createParser = () => {
-        const handlers = require('jsdoc/src/handlers');
-        const parser = require('jsdoc/src/parser');
-        const plugins = require('jsdoc/plugins');
+        const handlers = require('./lib/jsdoc/src/handlers');
+        const parser = require('./lib/jsdoc/src/parser');
+        const plugins = require('./lib/jsdoc/plugins');
 
         app.jsdoc.parser = parser.createParser(env.conf.parser);
 
@@ -355,9 +349,9 @@ module.exports = (() => {
     };
 
     cli.parseFiles = () => {
-        const augment = require('jsdoc/augment');
-        const borrow = require('jsdoc/borrow');
-        const Package = require('jsdoc/package').Package;
+        const augment = require('./lib/jsdoc/augment');
+        const borrow = require('./lib/jsdoc/borrow');
+        const Package = require('./lib/jsdoc/package').Package;
 
         let docs;
         let packageDocs;
@@ -394,13 +388,13 @@ module.exports = (() => {
     };
 
     cli.dumpParseResults = () => {
-        console.log(require('jsdoc/util/dumper').dump(props.docs));
+        console.log(require('./lib/jsdoc/util/dumper').dump(props.docs));
 
         return cli;
     };
 
     cli.resolveTutorials = () => {
-        const resolver = require('jsdoc/tutorial/resolver');
+        const resolver = require('./lib/jsdoc/tutorial/resolver');
 
         if (env.opts.tutorials) {
             resolver.load(env.opts.tutorials);
@@ -411,8 +405,8 @@ module.exports = (() => {
     };
 
     cli.generateDocs = () => {
-        const path = require('jsdoc/path');
-        const resolver = require('jsdoc/tutorial/resolver');
+        const path = require('./lib/jsdoc/path');
+        const resolver = require('./lib/jsdoc/tutorial/resolver');
         const taffy = require('taffydb').taffy;
 
         let template;

--- a/jsdoc.js
+++ b/jsdoc.js
@@ -1,93 +1,32 @@
 #!/usr/bin/env node
-/* global require: true */
 
-// initialize the environment for Node.js
-(() => {
-    const fs = require('fs');
-    const path = require('path');
+const fs = require('fs');
+const path = require('path');
+const env = require('./lib/jsdoc/env');
+const cli = require('./cli');
 
-    let env;
-    let jsdocPath = __dirname;
-    const pwd = process.cwd();
+let jsdocPath = __dirname;
 
-    // Create a custom require method that adds `lib/jsdoc` and `node_modules` to the module
-    // lookup path. This makes it possible to `require('jsdoc/foo')` from external templates and
-    // plugins, and within JSDoc itself. It also allows external templates and plugins to
-    // require JSDoc's module dependencies without installing them locally.
-    require = require('requizzle')({
-        requirePaths: {
-            before: [path.join(__dirname, 'lib')],
-            after: [path.join(__dirname, 'node_modules')]
-        },
-        infect: true
-    });
+// resolve the path if it's a symlink
+if ( fs.statSync(jsdocPath).isSymbolicLink() ) {
+    jsdocPath = path.resolve( path.dirname(jsdocPath), fs.readlinkSync(jsdocPath) );
+}
 
-    // resolve the path if it's a symlink
-    if ( fs.statSync(jsdocPath).isSymbolicLink() ) {
-        jsdocPath = path.resolve( path.dirname(jsdocPath), fs.readlinkSync(jsdocPath) );
-    }
+env.dirname = jsdocPath;
+env.pwd = process.cwd();
+env.args = process.argv.slice(2);
 
-    env = require('./lib/jsdoc/env');
-    env.dirname = jsdocPath;
-    env.pwd = pwd;
-    env.args = process.argv.slice(2);
-})();
+function cb(errorCode) {
+    cli.logFinish();
+    cli.exit(errorCode || 0);
+}
 
-/**
- * Data about the environment in which JSDoc is running, including the configuration settings that
- * were used to run JSDoc.
- *
- * @deprecated As of JSDoc 3.4.0. Use `require('jsdoc/env')` to access the `env` object. The global
- * `env` object will be removed in a future release.
- * @namespace
- * @name env
- */
-global.env = (() => require('./lib/jsdoc/env'))();
+cli.setVersionInfo()
+    .loadConfig();
 
-/**
- * Data that must be shared across the entire application.
- *
- * @deprecated As of JSDoc 3.4.0. Avoid using the `app` object. The global `app` object and the
- * `jsdoc/app` module will be removed in a future release.
- * @namespace
- * @name app
- */
-global.app = (() => require('./lib/jsdoc/app'))();
+if (!env.opts.test) {
+    cli.configureLogger();
+}
 
-(() => {
-    const env = global.env;
-    const cli = require('./cli');
-
-    function cb(errorCode) {
-        cli.logFinish();
-        cli.exit(errorCode || 0);
-    }
-
-    cli.setVersionInfo()
-        .loadConfig();
-
-    if (!env.opts.test) {
-        cli.configureLogger();
-    }
-
-    cli.logStart();
-
-    if (env.opts.debug) {
-        /**
-         * Recursively print an object's properties to stdout. This method is safe to use with
-         * objects that contain circular references.
-         *
-         * This method is available only when JSDoc is run with the `--debug` option.
-         *
-         * @global
-         * @name dump
-         * @private
-         * @param {...*} obj - Object(s) to print to stdout.
-         */
-        global.dump = (...args) => {
-            console.log(require('./lib/jsdoc/util/dumper').dump(args));
-        };
-    }
-
-    cli.runCommand(cb);
-})();
+cli.logStart();
+cli.runCommand(cb);

--- a/lib/jsdoc/app.js
+++ b/lib/jsdoc/app.js
@@ -12,8 +12,8 @@ module.exports = {
      * @type {Object}
      */
     jsdoc: {
-        name: require('jsdoc/name'),
+        name: require('./name'),
         parser: null,
-        scanner: new (require('jsdoc/src/scanner').Scanner)()
+        scanner: new (require('./src/scanner').Scanner)()
     }
 };

--- a/lib/jsdoc/augment.js
+++ b/lib/jsdoc/augment.js
@@ -3,11 +3,11 @@
  * @module jsdoc/augment
  */
 
-const doop = require('jsdoc/util/doop');
+const doop = require('./util/doop');
 const jsdoc = {
-    doclet: require('jsdoc/doclet')
+    doclet: require('./doclet')
 };
-const name = require('jsdoc/name');
+const name = require('./name');
 
 const hasOwnProp = Object.prototype.hasOwnProperty;
 

--- a/lib/jsdoc/borrow.js
+++ b/lib/jsdoc/borrow.js
@@ -2,8 +2,8 @@
  * A collection of functions relating to resolving @borrows tags in JSDoc symbols.
  * @module jsdoc/borrow
  */
-const doop = require('jsdoc/util/doop');
-const SCOPE = require('jsdoc/name').SCOPE;
+const doop = require('./util/doop');
+const SCOPE = require('./name').SCOPE;
 
 function cloneBorrowedDoclets({borrowed, longname}, doclets) {
     borrowed.forEach(({from, as}) => {

--- a/lib/jsdoc/config.js
+++ b/lib/jsdoc/config.js
@@ -1,7 +1,7 @@
 /**
  * @module jsdoc/config
  */
-const stripBom = require('jsdoc/util/stripbom');
+const stripBom = require('./util/stripbom');
 const stripJsonComments = require('strip-json-comments');
 
 function mergeRecurse(target, source) {

--- a/lib/jsdoc/doclet.js
+++ b/lib/jsdoc/doclet.js
@@ -3,21 +3,21 @@
  */
 const _ = require('underscore');
 const jsdoc = {
-    env: require('jsdoc/env'),
-    name: require('jsdoc/name'),
+    env: require('./env'),
+    name: require('./name'),
     src: {
-        astnode: require('jsdoc/src/astnode'),
-        Syntax: require('jsdoc/src/syntax').Syntax
+        astnode: require('./src/astnode'),
+        Syntax: require('./src/syntax').Syntax
     },
     tag: {
-        Tag: require('jsdoc/tag').Tag,
-        dictionary: require('jsdoc/tag/dictionary')
+        Tag: require('./tag').Tag,
+        dictionary: require('./tag/dictionary')
     },
     util: {
-        doop: require('jsdoc/util/doop')
+        doop: require('./util/doop')
     }
 };
-const path = require('jsdoc/path');
+const path = require('./path');
 const Syntax = jsdoc.src.Syntax;
 const util = require('util');
 
@@ -164,8 +164,8 @@ function fixDescription(docletSrc, {code}) {
  */
 exports._replaceDictionary = function _replaceDictionary(dict) {
     jsdoc.tag.dictionary = dict;
-    require('jsdoc/tag')._replaceDictionary(dict);
-    require('jsdoc/util/templateHelper')._replaceDictionary(dict);
+    require('./tag')._replaceDictionary(dict);
+    require('./util/templateHelper')._replaceDictionary(dict);
 };
 
 function removeGlobal(longname) {

--- a/lib/jsdoc/opts/args.js
+++ b/lib/jsdoc/opts/args.js
@@ -2,8 +2,8 @@
  * @module jsdoc/opts/args
  * @requires jsdoc/opts/argparser
  */
-const ArgParser = require('jsdoc/opts/argparser');
-const cast = require('jsdoc/util/cast').cast;
+const ArgParser = require('./argparser');
+const cast = require('../util/cast').cast;
 const querystring = require('querystring');
 
 let ourOptions;

--- a/lib/jsdoc/package.js
+++ b/lib/jsdoc/package.js
@@ -1,5 +1,5 @@
-const logger = require('jsdoc/util/logger');
-const stripBom = require('jsdoc/util/stripbom');
+const logger = require('./util/logger');
+const stripBom = require('./util/stripbom');
 
 /**
  * Provides access to information about a JavaScript package.

--- a/lib/jsdoc/path.js
+++ b/lib/jsdoc/path.js
@@ -2,7 +2,7 @@
  * Extended version of the standard `path` module.
  * @module jsdoc/path
  */
-const env = require('jsdoc/env');
+const env = require('./env');
 const fs = require('fs');
 const path = require('path');
 

--- a/lib/jsdoc/plugins.js
+++ b/lib/jsdoc/plugins.js
@@ -2,7 +2,7 @@
  * Utility functions to support the JSDoc plugin framework.
  * @module jsdoc/plugins
  */
-const dictionary = require('jsdoc/tag/dictionary');
+const dictionary = require('./tag/dictionary');
 
 function addHandlers(handlers, parser) {
     Object.keys(handlers).forEach(eventName => {

--- a/lib/jsdoc/readme.js
+++ b/lib/jsdoc/readme.js
@@ -2,9 +2,9 @@
  * Make the contents of a README file available to include in the output.
  * @module jsdoc/readme
  */
-const env = require('jsdoc/env');
-const fs = require('jsdoc/fs');
-const markdown = require('jsdoc/util/markdown');
+const env = require('./env');
+const fs = require('./fs');
+const markdown = require('./util/markdown');
 
 /**
  * Represents a README file.

--- a/lib/jsdoc/src/astbuilder.js
+++ b/lib/jsdoc/src/astbuilder.js
@@ -1,6 +1,6 @@
 const babelParser = require('@babel/parser');
-const env = require('jsdoc/env');
-const logger = require('jsdoc/util/logger');
+const env = require('../env');
+const logger = require('../util/logger');
 
 // exported so we can use them in tests
 const parserOptions = exports.parserOptions = {

--- a/lib/jsdoc/src/astnode.js
+++ b/lib/jsdoc/src/astnode.js
@@ -1,9 +1,9 @@
 // TODO: docs
 /** @module jsdoc/src/astnode */
-const cast = require('jsdoc/util/cast').cast;
-const env = require('jsdoc/env');
-const name = require('jsdoc/name');
-const Syntax = require('jsdoc/src/syntax').Syntax;
+const cast = require('../util/cast').cast;
+const env = require('../env');
+const name = require('../name');
+const Syntax = require('./syntax').Syntax;
 const util = require('util');
 
 // Counter for generating unique node IDs.

--- a/lib/jsdoc/src/filter.js
+++ b/lib/jsdoc/src/filter.js
@@ -1,8 +1,8 @@
 /**
  * @module jsdoc/src/filter
  */
-const env = require('jsdoc/env');
-const path = require('jsdoc/path');
+const env = require('../env');
+const path = require('../path');
 
 function makeRegExp(config) {
     let regExp = null;

--- a/lib/jsdoc/src/handlers.js
+++ b/lib/jsdoc/src/handlers.js
@@ -3,13 +3,13 @@
  */
 const escape = require('escape-string-regexp');
 const jsdoc = {
-    doclet: require('jsdoc/doclet'),
-    name: require('jsdoc/name'),
+    doclet: require('../doclet'),
+    name: require('../name'),
     src: {
-        syntax: require('jsdoc/src/syntax')
+        syntax: require('./syntax')
     },
     util: {
-        logger: require('jsdoc/util/logger')
+        logger: require('../util/logger')
     }
 };
 

--- a/lib/jsdoc/src/parser.js
+++ b/lib/jsdoc/src/parser.js
@@ -2,27 +2,27 @@
  * @module jsdoc/src/parser
  */
 const EventEmitter = require('events').EventEmitter;
-const fs = require('jsdoc/fs');
+const fs = require('../fs');
 const jsdoc = {
-    doclet: require('jsdoc/doclet'),
-    env: require('jsdoc/env'),
-    name: require('jsdoc/name'),
+    doclet: require('../doclet'),
+    env: require('../env'),
+    name: require('../name'),
     src: {
-        astnode: require('jsdoc/src/astnode'),
-        syntax: require('jsdoc/src/syntax')
+        astnode: require('./astnode'),
+        syntax: require('./syntax')
     },
     util: {
-        doop: require('jsdoc/util/doop')
+        doop: require('../util/doop')
     }
 };
-const logger = require('jsdoc/util/logger');
+const logger = require('../util/logger');
 
 const hasOwnProp = Object.prototype.hasOwnProperty;
 const Syntax = jsdoc.src.syntax.Syntax;
 
 // TODO: docs
 const PARSERS = exports.PARSERS = {
-    js: 'jsdoc/src/parser'
+    js: './parser'
 };
 /* eslint-disable no-script-url */
 // Prefix for JavaScript strings that were provided in lieu of a filename.
@@ -103,9 +103,9 @@ class Parser extends EventEmitter {
 
         this.clear();
 
-        this._astBuilder = builderInstance || new (require('jsdoc/src/astbuilder').AstBuilder)();
-        this._visitor = visitorInstance || new (require('jsdoc/src/visitor').Visitor)();
-        this._walker = walkerInstance || new (require('jsdoc/src/walker').Walker)();
+        this._astBuilder = builderInstance || new (require('./astbuilder').AstBuilder)();
+        this._visitor = visitorInstance || new (require('./visitor').Visitor)();
+        this._walker = walkerInstance || new (require('./walker').Walker)();
 
         this._visitor.setParser(this);
 

--- a/lib/jsdoc/src/scanner.js
+++ b/lib/jsdoc/src/scanner.js
@@ -3,10 +3,10 @@
  * @requires module:jsdoc/fs
  */
 const EventEmitter = require('events').EventEmitter;
-const env = require('jsdoc/env');
-const fs = require('jsdoc/fs');
-const logger = require('jsdoc/util/logger');
-const path = require('jsdoc/path');
+const env = require('../env');
+const fs = require('../fs');
+const logger = require('../util/logger');
+const path = require('../path');
 
 /**
  * @extends module:events.EventEmitter

--- a/lib/jsdoc/src/visitor.js
+++ b/lib/jsdoc/src/visitor.js
@@ -4,14 +4,14 @@
 // TODO: consider exporting more stuff so users can override it
 
 const jsdoc = {
-    doclet: require('jsdoc/doclet'),
-    name: require('jsdoc/name'),
+    doclet: require('../doclet'),
+    name: require('../name'),
     src: {
-        astnode: require('jsdoc/src/astnode'),
-        syntax: require('jsdoc/src/syntax')
+        astnode: require('./astnode'),
+        syntax: require('./syntax')
     },
     util: {
-        logger: require('jsdoc/util/logger')
+        logger: require('../util/logger')
     }
 };
 

--- a/lib/jsdoc/src/walker.js
+++ b/lib/jsdoc/src/walker.js
@@ -3,9 +3,9 @@
  *
  * @module jsdoc/src/walker
  */
-const astnode = require('jsdoc/src/astnode');
-const logger = require('jsdoc/util/logger');
-const Syntax = require('jsdoc/src/syntax').Syntax;
+const astnode = require('./astnode');
+const logger = require('../util/logger');
+const Syntax = require('./syntax').Syntax;
 
 // TODO: docs
 function getCurrentScope(scopes) {

--- a/lib/jsdoc/tag.js
+++ b/lib/jsdoc/tag.js
@@ -10,17 +10,17 @@
  * @requires module:util
  */
 const jsdoc = {
-    env: require('jsdoc/env'),
+    env: require('./env'),
     tag: {
-        dictionary: require('jsdoc/tag/dictionary'),
-        validator: require('jsdoc/tag/validator'),
-        type: require('jsdoc/tag/type')
+        dictionary: require('./tag/dictionary'),
+        validator: require('./tag/validator'),
+        type: require('./tag/type')
     },
     util: {
-        logger: require('jsdoc/util/logger')
+        logger: require('./util/logger')
     }
 };
-const path = require('jsdoc/path');
+const path = require('./path');
 const util = require('util');
 
 // Check whether the text is the same as a symbol name with leading or trailing whitespace. If so,

--- a/lib/jsdoc/tag/dictionary.js
+++ b/lib/jsdoc/tag/dictionary.js
@@ -1,5 +1,5 @@
 /** @module jsdoc/tag/dictionary */
-const definitions = require('jsdoc/tag/dictionary/definitions');
+const definitions = require('./dictionary/definitions');
 
 const hasOwnProp = Object.prototype.hasOwnProperty;
 

--- a/lib/jsdoc/tag/dictionary/definitions.js
+++ b/lib/jsdoc/tag/dictionary/definitions.js
@@ -4,22 +4,22 @@
  */
 const _ = require('underscore');
 const jsdoc = {
-    env: require('jsdoc/env'),
-    name: require('jsdoc/name'),
+    env: require('../../env'),
+    name: require('../../name'),
     src: {
-        astnode: require('jsdoc/src/astnode')
+        astnode: require('../../src/astnode')
     },
     tag: {
-        inline: require('jsdoc/tag/inline'),
-        type: require('jsdoc/tag/type')
+        inline: require('../inline'),
+        type: require('../type')
     },
     util: {
-        doop: require('jsdoc/util/doop'),
-        logger: require('jsdoc/util/logger')
+        doop: require('../../util/doop'),
+        logger: require('../../util/logger')
     }
 };
-const path = require('jsdoc/path');
-const Syntax = require('jsdoc/src/syntax').Syntax;
+const path = require('../../path');
+const Syntax = require('../../src/syntax').Syntax;
 
 const hasOwnProp = Object.prototype.hasOwnProperty;
 

--- a/lib/jsdoc/tag/type.js
+++ b/lib/jsdoc/tag/type.js
@@ -3,12 +3,12 @@
  */
 const catharsis = require('catharsis');
 const jsdoc = {
-    name: require('jsdoc/name'),
+    name: require('../name'),
     tag: {
-        inline: require('jsdoc/tag/inline')
+        inline: require('./inline')
     },
     util: {
-        cast: require('jsdoc/util/cast')
+        cast: require('../util/cast')
     }
 };
 const util = require('util');

--- a/lib/jsdoc/tag/validator.js
+++ b/lib/jsdoc/tag/validator.js
@@ -2,8 +2,8 @@
  * @module jsdoc/tag/validator
  * @requires jsdoc/tag/dictionary
  */
-const env = require('jsdoc/env');
-const logger = require('jsdoc/util/logger');
+const env = require('../env');
+const logger = require('../util/logger');
 
 function buildMessage(tagName, {filename, lineno, comment}, desc) {
     let result = `The @${tagName} tag ${desc}. File: ${filename}, line: ${lineno}`;

--- a/lib/jsdoc/template.js
+++ b/lib/jsdoc/template.js
@@ -3,7 +3,7 @@
  * @module jsdoc/template
  */
 const _ = require('underscore');
-const fs = require('jsdoc/fs');
+const fs = require('./fs');
 const path = require('path');
 
 /**

--- a/lib/jsdoc/tutorial.js
+++ b/lib/jsdoc/tutorial.js
@@ -1,7 +1,7 @@
 /**
  * @module jsdoc/tutorial
  */
-const markdown = require('jsdoc/util/markdown');
+const markdown = require('./util/markdown');
 
 const hasOwnProp = Object.prototype.hasOwnProperty;
 

--- a/lib/jsdoc/tutorial/resolver.js
+++ b/lib/jsdoc/tutorial/resolver.js
@@ -1,12 +1,12 @@
 /**
  * @module jsdoc/tutorial/resolver
  */
-const env = require('jsdoc/env');
-const fs = require('jsdoc/fs');
-const logger = require('jsdoc/util/logger');
+const env = require('../env');
+const fs = require('../fs');
+const logger = require('../util/logger');
 const path = require('path');
-const stripBom = require('jsdoc/util/stripbom');
-const tutorial = require('jsdoc/tutorial');
+const stripBom = require('../util/stripbom');
+const tutorial = require('../tutorial');
 
 const hasOwnProp = Object.prototype.hasOwnProperty;
 

--- a/lib/jsdoc/util/error.js
+++ b/lib/jsdoc/util/error.js
@@ -20,7 +20,7 @@
  * @memberof module:jsdoc/util/error
  */
 exports.handle = e => {
-    const logger = require('jsdoc/util/logger');
+    const logger = require('./logger');
     let msg = e ? ( e.message || JSON.stringify(e) ) : '';
 
     // include the error type if it's an Error object

--- a/lib/jsdoc/util/logger.js
+++ b/lib/jsdoc/util/logger.js
@@ -23,7 +23,7 @@
  * @module jsdoc/util/logger
  * @extends module:events.EventEmitter
  * @example
- * var logger = require('jsdoc/util/logger');
+ * var logger = require('./logger');
  *
  * var data = {
  *   foo: 'bar'

--- a/lib/jsdoc/util/markdown.js
+++ b/lib/jsdoc/util/markdown.js
@@ -2,12 +2,12 @@
  * Provides access to Markdown-related functions.
  * @module jsdoc/util/markdown
  */
-const env = require('jsdoc/env');
-const logger = require('jsdoc/util/logger');
+const env = require('../env');
+const logger = require('./logger');
 const MarkdownIt = require('markdown-it');
 const marked = require('marked');
 const mda = require('markdown-it-anchor');
-const path = require('jsdoc/path');
+const path = require('../path');
 const util = require('util');
 
 /**

--- a/lib/jsdoc/util/templateHelper.js
+++ b/lib/jsdoc/util/templateHelper.js
@@ -2,11 +2,11 @@
  * @module jsdoc/util/templateHelper
  */
 const catharsis = require('catharsis');
-let dictionary = require('jsdoc/tag/dictionary');
-const env = require('jsdoc/env');
-const inline = require('jsdoc/tag/inline');
-const logger = require('jsdoc/util/logger');
-const name = require('jsdoc/name');
+let dictionary = require('../tag/dictionary');
+const env = require('../env');
+const inline = require('../tag/inline');
+const logger = require('./logger');
+const name = require('../name');
 const util = require('util');
 
 const hasOwnProp = Object.prototype.hasOwnProperty;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1740,7 +1740,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1761,12 +1762,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1781,17 +1784,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1908,7 +1914,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1920,6 +1927,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1934,6 +1942,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1941,12 +1950,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1965,6 +1976,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2045,7 +2057,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2057,6 +2070,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2142,7 +2156,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2178,6 +2193,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2197,6 +2213,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2240,12 +2257,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -3434,6 +3453,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -3758,7 +3778,8 @@
         "is-buffer": {
           "version": "1.1.6",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -3842,6 +3863,7 @@
           "version": "3.2.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -3888,7 +3910,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -4154,7 +4177,8 @@
         "repeat-string": {
           "version": "1.6.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "require-directory": {
           "version": "2.1.1",
@@ -5127,21 +5151,6 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true
-    },
-    "requizzle": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.1.tgz",
-      "integrity": "sha1-aUPDUwxNmn5G8c3dUcFY/GcM294=",
-      "requires": {
-        "underscore": "~1.6.0"
-      },
-      "dependencies": {
-        "underscore": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
-        }
-      }
     },
     "resolve": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "3.6.0-dev",
   "revision": "1547606083759",
   "description": "An API documentation generator for JavaScript.",
-  "keywords": ["documentation", "javascript"],
+  "keywords": [
+    "documentation",
+    "javascript"
+  ],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -20,7 +23,6 @@
     "markdown-it-anchor": "~5.0.2",
     "marked": "~0.6.0",
     "mkdirp": "~0.5.1",
-    "requizzle": "~0.2.1",
     "strip-json-comments": "~2.0.1",
     "taffydb": "2.6.2",
     "underscore": "~1.9.1"
@@ -42,18 +44,24 @@
     "jsdoc": "./jsdoc.js"
   },
   "greenkeeper": {
-    "ignore": ["taffydb"]
+    "ignore": [
+      "taffydb"
+    ]
   },
   "bugs": "https://github.com/jsdoc3/jsdoc/issues",
   "author": {
     "name": "Michael Mathews",
     "email": "micmath@gmail.com"
   },
-  "contributors": [{
-    "url": "https://github.com/jsdoc3/jsdoc/graphs/contributors"
-  }],
-  "maintainers": [{
-    "name": "Jeff Williams",
-    "email": "jeffrey.l.williams@gmail.com"
-  }]
+  "contributors": [
+    {
+      "url": "https://github.com/jsdoc3/jsdoc/graphs/contributors"
+    }
+  ],
+  "maintainers": [
+    {
+      "name": "Jeff Williams",
+      "email": "jeffrey.l.williams@gmail.com"
+    }
+  ]
 }

--- a/plugins/eventDumper.js
+++ b/plugins/eventDumper.js
@@ -4,9 +4,9 @@
  * @module plugins/eventDumper
  */
 const _ = require('underscore');
-const doop = require('jsdoc/util/doop');
-const dump = require('jsdoc/util/dumper').dump;
-const env = require('jsdoc/env');
+const doop = require('../lib/jsdoc/util/doop');
+const dump = require('../lib/jsdoc/util/dumper').dump;
+const env = require('../lib/jsdoc/env');
 const util = require('util');
 
 const conf = env.conf.eventDumper || {};

--- a/plugins/markdown.js
+++ b/plugins/markdown.js
@@ -3,7 +3,7 @@
  *
  * @module plugins/markdown
  */
-const env = require('jsdoc/env');
+const env = require('../lib/jsdoc/env');
 
 const config = env.conf.markdown || {};
 const defaultTags = [
@@ -18,7 +18,7 @@ const defaultTags = [
     'summary'
 ];
 const hasOwnProp = Object.prototype.hasOwnProperty;
-const parse = require('jsdoc/util/markdown').getParser();
+const parse = require('../lib/jsdoc/util/markdown').getParser();
 let tags = [];
 let excludeTags = [];
 

--- a/plugins/partial.js
+++ b/plugins/partial.js
@@ -3,8 +3,8 @@
  *
  * @module plugins/partial
  */
-const env = require('jsdoc/env');
-const fs = require('jsdoc/fs');
+const env = require('../lib/jsdoc/env');
+const fs = require('../lib/jsdoc/fs');
 const path = require('path');
 
 exports.handlers = {

--- a/plugins/sourcetag.js
+++ b/plugins/sourcetag.js
@@ -1,7 +1,7 @@
 /**
  * @module plugins/sourcetag
  */
-const logger = require('jsdoc/util/logger');
+const logger = require('../lib/jsdoc/util/logger');
 
 exports.handlers = {
     /**

--- a/plugins/test/specs/commentConvert.js
+++ b/plugins/test/specs/commentConvert.js
@@ -1,8 +1,8 @@
 'use strict';
 
 describe('commentConvert plugin', function() {
-    var env = require('jsdoc/env');
-    var path = require('jsdoc/path');
+    var env = require('../../../lib/jsdoc/env');
+    var path = require('../../../lib/jsdoc/path');
 
     var docSet;
     var parser = jasmine.createParser();
@@ -10,7 +10,7 @@ describe('commentConvert plugin', function() {
     var pluginPathResolved = path.join(env.dirname, pluginPath);
     var plugin = require(pluginPathResolved);
 
-    require('jsdoc/plugins').installPlugins([pluginPathResolved], parser);
+    require('../../../lib/jsdoc/plugins').installPlugins([pluginPathResolved], parser);
     docSet = jasmine.getDocSetFromFile(pluginPath + '.js', parser);
 
     it('should convert ///-style comments into jsdoc comments', function() {

--- a/plugins/test/specs/escapeHtml.js
+++ b/plugins/test/specs/escapeHtml.js
@@ -1,15 +1,15 @@
 'use strict';
 
 describe('escapeHtml plugin', function() {
-    var env = require('jsdoc/env');
-    var path = require('jsdoc/path');
+    var env = require('../../../lib/jsdoc/env');
+    var path = require('../../../lib/jsdoc/path');
 
     var docSet;
     var parser = jasmine.createParser();
     var pluginPath = 'plugins/escapeHtml';
     var pluginPathResolved = path.join(env.dirname, pluginPath);
 
-    require('jsdoc/plugins').installPlugins([pluginPathResolved], parser);
+    require('../../../lib/jsdoc/plugins').installPlugins([pluginPathResolved], parser);
     docSet = jasmine.getDocSetFromFile(pluginPath + '.js', parser);
 
     it("should escape '&', '<' and newlines in doclet descriptions", function() {

--- a/plugins/test/specs/markdown.js
+++ b/plugins/test/specs/markdown.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var env = require('jsdoc/env');
-var path = require('jsdoc/path');
+var env = require('../../../lib/jsdoc/env');
+var path = require('../../../lib/jsdoc/path');
 
 describe('markdown plugin', function() {
     var pluginPath = 'plugins/markdown';

--- a/plugins/test/specs/overloadHelper.js
+++ b/plugins/test/specs/overloadHelper.js
@@ -1,8 +1,8 @@
 'use strict';
 
 describe('plugins/overloadHelper', function() {
-    var env = require('jsdoc/env');
-    var path = require('jsdoc/path');
+    var env = require('../../../lib/jsdoc/env');
+    var path = require('../../../lib/jsdoc/path');
 
     var docSet;
     var parser = jasmine.createParser();
@@ -10,7 +10,7 @@ describe('plugins/overloadHelper', function() {
     var pluginPathResolved = path.resolve(env.dirname, pluginPath);
     var plugin = require(pluginPathResolved);
 
-    require('jsdoc/plugins').installPlugins([pluginPathResolved], parser);
+    require('../../../lib/jsdoc/plugins').installPlugins([pluginPathResolved], parser);
     docSet = jasmine.getDocSetFromFile('plugins/test/fixtures/overloadHelper.js', parser);
 
     it('should exist', function() {

--- a/plugins/test/specs/railsTemplate.js
+++ b/plugins/test/specs/railsTemplate.js
@@ -1,15 +1,15 @@
 'use strict';
 
 describe('railsTemplate plugin', function() {
-    var env = require('jsdoc/env');
-    var path = require('jsdoc/path');
+    var env = require('../../../lib/jsdoc/env');
+    var path = require('../../../lib/jsdoc/path');
 
     var parser = jasmine.createParser();
     var pluginPath = path.join(env.dirname, 'plugins/railsTemplate');
     var plugin = require(pluginPath);
 
-    require('jsdoc/plugins').installPlugins([pluginPath], parser);
-    require('jsdoc/src/handlers').attachTo(parser);
+    require('../../../lib/jsdoc/plugins').installPlugins([pluginPath], parser);
+    require('../../../lib/jsdoc/src/handlers').attachTo(parser);
 
     it('should remove <% %> rails template tags from the source of *.erb files', function() {
         var docSet = parser.parse([path.join(env.dirname, 'plugins/test/fixtures/railsTemplate.js.erb')]);

--- a/plugins/test/specs/shout.js
+++ b/plugins/test/specs/shout.js
@@ -1,8 +1,8 @@
 'use strict';
 
 describe('shout plugin', function() {
-    var env = require('jsdoc/env');
-    var path = require('jsdoc/path');
+    var env = require('../../../lib/jsdoc/env');
+    var path = require('../../../lib/jsdoc/path');
 
     var docSet;
     var parser = jasmine.createParser();
@@ -10,7 +10,7 @@ describe('shout plugin', function() {
     var pluginPathResolved = path.join(env.dirname, pluginPath);
     var plugin = require(pluginPathResolved);
 
-    require('jsdoc/plugins').installPlugins([pluginPathResolved], parser);
+    require('../../../lib/jsdoc/plugins').installPlugins([pluginPathResolved], parser);
     docSet = jasmine.getDocSetFromFile(pluginPath + '.js', parser);
 
     it('should make the description uppercase', function() {

--- a/plugins/test/specs/sourcetag.js
+++ b/plugins/test/specs/sourcetag.js
@@ -1,15 +1,15 @@
 'use strict';
 
 describe('sourcetag plugin', function() {
-    var env = require('jsdoc/env');
-    var path = require('jsdoc/path');
+    var env = require('../../../lib/jsdoc/env');
+    var path = require('../../../lib/jsdoc/path');
 
     var docSet;
     var parser = jasmine.createParser();
     var pluginPath = 'plugins/sourcetag';
     var pluginPathResolved = path.join(env.dirname, pluginPath);
 
-    require('jsdoc/plugins').installPlugins([pluginPathResolved], parser);
+    require('../../../lib/jsdoc/plugins').installPlugins([pluginPathResolved], parser);
     docSet = jasmine.getDocSetFromFile(pluginPath + '.js', parser);
 
     it("should set the lineno and filename of the doclet's meta property", function() {

--- a/plugins/test/specs/underscore.js
+++ b/plugins/test/specs/underscore.js
@@ -1,8 +1,8 @@
 'use strict';
 
 describe('underscore plugin', function () {
-    var env = require('jsdoc/env');
-    var path = require('jsdoc/path');
+    var env = require('../../../lib/jsdoc/env');
+    var path = require('../../../lib/jsdoc/path');
 
     var docSet;
     var parser = jasmine.createParser();
@@ -11,7 +11,7 @@ describe('underscore plugin', function () {
     var pluginPathResolved = path.join(env.dirname, pluginPath);
     var plugin = require(pluginPathResolved);
 
-    require('jsdoc/plugins').installPlugins([pluginPathResolved], parser);
+    require('../../../lib/jsdoc/plugins').installPlugins([pluginPathResolved], parser);
     docSet = jasmine.getDocSetFromFile(fixturePath + '.js', parser);
 
     it('should not mark normal, public properties as private', function() {

--- a/templates/default/publish.js
+++ b/templates/default/publish.js
@@ -1,11 +1,11 @@
-const doop = require('jsdoc/util/doop');
-const env = require('jsdoc/env');
-const fs = require('jsdoc/fs');
-const helper = require('jsdoc/util/templateHelper');
-const logger = require('jsdoc/util/logger');
-const path = require('jsdoc/path');
+const doop = require('../../lib/jsdoc/util/doop');
+const env = require('../../lib/jsdoc/env');
+const fs = require('../../lib/jsdoc/fs');
+const helper = require('../../lib/jsdoc/util/templateHelper');
+const logger = require('../../lib/jsdoc/util/logger');
+const path = require('../../lib/jsdoc/path');
 const taffy = require('taffydb').taffy;
-const template = require('jsdoc/template');
+const template = require('../../lib/jsdoc/template');
 const util = require('util');
 
 const htmlsafe = helper.htmlsafe;
@@ -513,8 +513,8 @@ exports.publish = (taffyData, opts, tutorials) => {
         staticFilePaths = conf.default.staticFiles.include ||
             conf.default.staticFiles.paths ||
             [];
-        staticFileFilter = new (require('jsdoc/src/filter').Filter)(conf.default.staticFiles);
-        staticFileScanner = new (require('jsdoc/src/scanner').Scanner)();
+        staticFileFilter = new (require('../../lib/jsdoc/src/filter').Filter)(conf.default.staticFiles);
+        staticFileScanner = new (require('../../lib/jsdoc/src/scanner').Scanner)();
 
         staticFilePaths.forEach(filePath => {
             let extraStaticFiles;

--- a/templates/haruki/publish.js
+++ b/templates/haruki/publish.js
@@ -215,7 +215,7 @@ exports.publish = (data, {destination, query}) => {
             console.log( xml.parse('jsdoc', root) );
         }
         else {
-            console.log( require('jsdoc/util/dumper').dump(root) );
+            console.log( require('../../lib/jsdoc/util/dumper').dump(root) );
         }
     }
     else {

--- a/test/jasmine-jsdoc.js
+++ b/test/jasmine-jsdoc.js
@@ -1,21 +1,21 @@
 /* global jasmine: true */
 'use strict';
 
-var fs = require('jsdoc/fs');
-var path = require('jsdoc/path');
+var fs = require('../lib/jsdoc/fs');
+var path = require('../lib/jsdoc/path');
 
 var jsdoc = {
-    augment: require('jsdoc/augment'),
-    doclet: require('jsdoc/doclet'),
-    env: require('jsdoc/env'),
-    schema: require('jsdoc/schema'),
+    augment: require('../lib/jsdoc/augment'),
+    doclet: require('../lib/jsdoc/doclet'),
+    env: require('../lib/jsdoc/env'),
+    schema: require('../lib/jsdoc/schema'),
     src: {
-        handlers: require('jsdoc/src/handlers'),
-        parser: require('jsdoc/src/parser')
+        handlers: require('../lib/jsdoc/src/handlers'),
+        parser: require('../lib/jsdoc/src/parser')
     },
     tag: {
-        dictionary: require('jsdoc/tag/dictionary'),
-        definitions: require('jsdoc/tag/dictionary/definitions')
+        dictionary: require('../lib/jsdoc/tag/dictionary'),
+        definitions: require('../lib/jsdoc/tag/dictionary/definitions')
     }
 };
 
@@ -160,7 +160,7 @@ jasmine.getDocSetFromFile = function(filename, parser, validate, augment) {
     }
 
     // test assume borrows have not yet been resolved
-    // require('jsdoc/borrow').resolveBorrows(doclets);
+    // require('../lib/jsdoc/borrow').resolveBorrows(doclets);
 
     // store the parse results for later validation
     if (validate !== false) {

--- a/test/runner.js
+++ b/test/runner.js
@@ -6,9 +6,9 @@
  * 3. Get the list of directories to run tests from
  * 4. Run Jasmine on each directory
  */
-var env = require('jsdoc/env');
-var fs = require('jsdoc/fs');
-var logger = require('jsdoc/util/logger');
+var env = require('../lib/jsdoc/env');
+var fs = require('../lib/jsdoc/fs');
+var logger = require('../lib/jsdoc/util/logger');
 var path = require('path');
 
 fs.existsSync = fs.existsSync || path.existsSync;

--- a/test/spec-collection.js
+++ b/test/spec-collection.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var fs = require('jsdoc/fs');
-var path = require('jsdoc/path');
+var fs = require('../lib/jsdoc/fs');
+var path = require('../lib/jsdoc/path');
 var klaw = require('klaw');
 
 var specs = [];

--- a/test/specs/documentation/also.js
+++ b/test/specs/documentation/also.js
@@ -1,4 +1,4 @@
-const env = require('jsdoc/env');
+const env = require('../../../lib/jsdoc/env');
 
 describe('multiple doclets per symbol', () => {
     function undocumented($) {
@@ -48,7 +48,7 @@ describe('multiple doclets per symbol', () => {
 
     it('When a file contains a JSDoc comment with an @also tag, and the "tags.allowUnknownTags" ' +
         'option is set to false, the file can be parsed without errors.', () => {
-        const logger = require('jsdoc/util/logger');
+        const logger = require('../../../lib/jsdoc/util/logger');
 
         const allowUnknownTags = Boolean(env.conf.tags.allowUnknownTags);
         const errors = [];

--- a/test/specs/documentation/emptycomments.js
+++ b/test/specs/documentation/emptycomments.js
@@ -1,4 +1,4 @@
-const logger = require('jsdoc/util/logger');
+const logger = require('../../../lib/jsdoc/util/logger');
 
 describe('empty JSDoc comments', () => {
     it('should not report an error when a JSDoc comment contains only whitespace', () => {

--- a/test/specs/documentation/jsx.js
+++ b/test/specs/documentation/jsx.js
@@ -1,6 +1,6 @@
 describe('JSX support', () => {
     it('should parse JSX files without errors', () => {
-        const logger = require('jsdoc/util/logger');
+        const logger = require('../../../lib/jsdoc/util/logger');
 
         function parseJsx() {
             return jasmine.getDocSetFromFile('test/fixtures/jsx.js');

--- a/test/specs/documentation/mixins.js
+++ b/test/specs/documentation/mixins.js
@@ -1,5 +1,5 @@
-const augment = require('jsdoc/augment');
-const name = require('jsdoc/name');
+const augment = require('../../../lib/jsdoc/augment');
+const name = require('../../../lib/jsdoc/name');
 
 describe('mixins', () => {
     describe('doclet augmentation', () => {

--- a/test/specs/documentation/modules.js
+++ b/test/specs/documentation/modules.js
@@ -1,6 +1,6 @@
 describe('module names', () => {
-    const env = require('jsdoc/env');
-    const path = require('jsdoc/path');
+    const env = require('../../../lib/jsdoc/env');
+    const path = require('../../../lib/jsdoc/path');
 
     let doclets;
 
@@ -14,7 +14,7 @@ describe('module names', () => {
         env.pwd = env.dirname;
         env.sourceFiles = [];
         srcParser = jasmine.createParser();
-        require('jsdoc/src/handlers').attachTo(srcParser);
+        require('../../../lib/jsdoc/src/handlers').attachTo(srcParser);
     });
 
     afterEach(() => {
@@ -37,7 +37,7 @@ describe('module names', () => {
     // Windows-specific test
     if ( /^win/.test(require('os').platform()) ) {
         it('should always use forward slashes when creating a name from the file path', () => {
-            const Doclet = require('jsdoc/doclet').Doclet;
+            const Doclet = require('../../../lib/jsdoc/doclet').Doclet;
             let doclet;
 
             env.sourceFiles = [

--- a/test/specs/jsdoc/augment.js
+++ b/test/specs/jsdoc/augment.js
@@ -1,7 +1,7 @@
 describe('jsdoc/augment', () => {
     // TODO: more tests
 
-    const augment = require('jsdoc/augment');
+    const augment = require('../../../lib/jsdoc/augment');
 
     it('should exist', () => {
         expect(augment).toBeDefined();

--- a/test/specs/jsdoc/config.js
+++ b/test/specs/jsdoc/config.js
@@ -1,6 +1,6 @@
 describe('jsdoc/config', () => {
     const jsdoc = {
-        config: require('jsdoc/config')
+        config: require('../../../lib/jsdoc/config')
     };
     const Config = jsdoc.config;
 

--- a/test/specs/jsdoc/doclet.js
+++ b/test/specs/jsdoc/doclet.js
@@ -2,7 +2,7 @@ describe('jsdoc/doclet', () => {
     // TODO: more tests
     const _ = require('underscore');
     const jsdoc = {
-        doclet: require('jsdoc/doclet')
+        doclet: require('../../../lib/jsdoc/doclet')
     };
     const Doclet = jsdoc.doclet.Doclet;
 
@@ -32,7 +32,7 @@ describe('jsdoc/doclet', () => {
                 doclet.setScope(scopeName);
             }
 
-            _.values(require('jsdoc/name').SCOPE.NAMES).forEach(scopeName => {
+            _.values(require('../../../lib/jsdoc/name').SCOPE.NAMES).forEach(scopeName => {
                 expect( setScope.bind(null, scopeName) ).not.toThrow();
             });
         });

--- a/test/specs/jsdoc/name.js
+++ b/test/specs/jsdoc/name.js
@@ -1,7 +1,7 @@
 describe('jsdoc/name', () => {
     const jsdoc = {
-        doclet: require('jsdoc/doclet'),
-        name: require('jsdoc/name')
+        doclet: require('../../../lib/jsdoc/doclet'),
+        name: require('../../../lib/jsdoc/name')
     };
 
     it('should exist', () => {

--- a/test/specs/jsdoc/opts/argparser.js
+++ b/test/specs/jsdoc/opts/argparser.js
@@ -1,5 +1,5 @@
 describe('jsdoc/opts/argparser', () => {
-    const ArgParser = require('jsdoc/opts/argparser');
+    const ArgParser = require('../../../lib/jsdoc/opts/argparser');
     let argParser;
     let ourOptions;
 

--- a/test/specs/jsdoc/opts/args.js
+++ b/test/specs/jsdoc/opts/args.js
@@ -1,5 +1,5 @@
 describe('jsdoc/opts/args', () => {
-    const args = require('jsdoc/opts/args');
+    const args = require('../../../lib/jsdoc/opts/args');
     const querystring = require('querystring');
 
     it('should exist', () => {

--- a/test/specs/jsdoc/package.js
+++ b/test/specs/jsdoc/package.js
@@ -2,8 +2,8 @@ const hasOwnProp = Object.prototype.hasOwnProperty;
 
 describe('jsdoc/package', () => {
     let emptyPackage;
-    const jsdocPackage = require('jsdoc/package');
-    const logger = require('jsdoc/util/logger');
+    const jsdocPackage = require('../../../lib/jsdoc/package');
+    const logger = require('../../../lib/jsdoc/util/logger');
     const Package = jsdocPackage.Package;
 
     function checkPackageProperty(name, value) {

--- a/test/specs/jsdoc/path.js
+++ b/test/specs/jsdoc/path.js
@@ -1,7 +1,7 @@
 describe('jsdoc/path', () => {
-    const env = require('jsdoc/env');
+    const env = require('../../../lib/jsdoc/env');
     const os = require('os');
-    const path = require('jsdoc/path');
+    const path = require('../../../lib/jsdoc/path');
     const standardPath = require('path');
 
     const isWindows = /^win/.test( os.platform() );

--- a/test/specs/jsdoc/plugins.js
+++ b/test/specs/jsdoc/plugins.js
@@ -1,5 +1,5 @@
 describe('jsdoc/plugins', () => {
-    const plugins = require('jsdoc/plugins');
+    const plugins = require('../../../lib/jsdoc/plugins');
 
     it('should exist', () => {
         expect(plugins).toBeDefined();

--- a/test/specs/jsdoc/readme.js
+++ b/test/specs/jsdoc/readme.js
@@ -1,5 +1,5 @@
 describe('jsdoc/readme', () => {
-    const jsdoc = { readme: require('jsdoc/readme') };
+    const jsdoc = { readme: require('../../../lib/jsdoc/readme') };
     const Readme = jsdoc.readme;
     const html = (new Readme('test/fixtures/markdowntest.md')).html;
 

--- a/test/specs/jsdoc/schema.js
+++ b/test/specs/jsdoc/schema.js
@@ -1,5 +1,5 @@
 describe('jsdoc/schema', () => {
-    const schema = require('jsdoc/schema');
+    const schema = require('../../../lib/jsdoc/schema');
 
     it('should exist', () => {
         expect(schema).toBeDefined();

--- a/test/specs/jsdoc/src/astbuilder.js
+++ b/test/specs/jsdoc/src/astbuilder.js
@@ -1,5 +1,5 @@
 describe('jsdoc/src/astbuilder', () => {
-    const astbuilder = require('jsdoc/src/astbuilder');
+    const astbuilder = require('./astbuilder');
 
     it('should exist', () => {
         expect(astbuilder).toBeDefined();
@@ -26,7 +26,7 @@ describe('jsdoc/src/astbuilder', () => {
 
         describe('build', () => {
             // TODO: more tests
-            const logger = require('jsdoc/util/logger');
+            const logger = require('../util/logger');
 
             beforeEach(() => {
                 spyOn(logger, 'error');

--- a/test/specs/jsdoc/src/astnode.js
+++ b/test/specs/jsdoc/src/astnode.js
@@ -1,9 +1,9 @@
 describe('jsdoc/src/astNode', () => {
-    const astBuilder = require('jsdoc/src/astbuilder');
-    const astNode = require('jsdoc/src/astnode');
+    const astBuilder = require('./astbuilder');
+    const astNode = require('./astnode');
     const babelParser = require('@babel/parser');
-    const env = require('jsdoc/env');
-    const Syntax = require('jsdoc/src/syntax').Syntax;
+    const env = require('../env');
+    const Syntax = require('./syntax').Syntax;
 
     function parse(str) {
         return babelParser.parse(str, astBuilder.parserOptions).program.body[0];

--- a/test/specs/jsdoc/src/filter.js
+++ b/test/specs/jsdoc/src/filter.js
@@ -1,7 +1,7 @@
 describe('jsdoc/src/filter', () => {
-    const env = require('jsdoc/env');
-    const filter = require('jsdoc/src/filter');
-    const path = require('jsdoc/path');
+    const env = require('../env');
+    const filter = require('./filter');
+    const path = require('../path');
 
     it('should exist', () => {
         expect(filter).toBeDefined();

--- a/test/specs/jsdoc/src/handlers.js
+++ b/test/specs/jsdoc/src/handlers.js
@@ -1,5 +1,5 @@
 describe('jsdoc/src/handlers', () => {
-    const handlers = require('jsdoc/src/handlers');
+    const handlers = require('./handlers');
 
     const testParser = jasmine.createParser();
 

--- a/test/specs/jsdoc/src/parser.js
+++ b/test/specs/jsdoc/src/parser.js
@@ -1,17 +1,17 @@
 /* eslint no-script-url: 0 */
 describe('jsdoc/src/parser', () => {
-    const fs = require('jsdoc/fs');
+    const fs = require('../fs');
     const jsdoc = {
-        env: require('jsdoc/env'),
+        env: require('../env'),
         src: {
-            handlers: require('jsdoc/src/handlers'),
-            parser: require('jsdoc/src/parser')
+            handlers: require('./handlers'),
+            parser: require('./parser')
         },
         util: {
-            logger: require('jsdoc/util/logger')
+            logger: require('../util/logger')
         }
     };
-    const path = require('jsdoc/path');
+    const path = require('../path');
 
     it('should exist', () => {
         expect(jsdoc.src.parser).toBeDefined();
@@ -104,19 +104,19 @@ describe('jsdoc/src/parser', () => {
 
         describe('astBuilder', () => {
             it('should contain an appropriate astBuilder by default', () => {
-                expect(parser.astBuilder instanceof (require('jsdoc/src/astbuilder')).AstBuilder).toBe(true);
+                expect(parser.astBuilder instanceof (require('./astbuilder')).AstBuilder).toBe(true);
             });
         });
 
         describe('visitor', () => {
             it('should contain an appropriate visitor by default', () => {
-                expect(parser.visitor instanceof (require('jsdoc/src/visitor')).Visitor).toBe(true);
+                expect(parser.visitor instanceof (require('./visitor')).Visitor).toBe(true);
             });
         });
 
         describe('walker', () => {
             it('should contain an appropriate walker by default', () => {
-                expect(parser.walker instanceof (require('jsdoc/src/walker')).Walker).toBe(true);
+                expect(parser.walker instanceof (require('./walker')).Walker).toBe(true);
             });
         });
 
@@ -179,7 +179,7 @@ describe('jsdoc/src/parser', () => {
                 const sourceCode = 'javascript:/** @class */function Foo() {}';
 
                 function handler(e) {
-                    const doop = require('jsdoc/util/doop');
+                    const doop = require('../util/doop');
 
                     e.doclet = doop(e.doclet);
                     e.doclet.foo = 'bar';
@@ -193,7 +193,7 @@ describe('jsdoc/src/parser', () => {
             });
 
             it('should call AST node visitors', () => {
-                const Syntax = require('jsdoc/src/syntax').Syntax;
+                const Syntax = require('./syntax').Syntax;
 
                 let args;
                 const sourceCode = ['javascript:/** foo */var foo;'];
@@ -290,7 +290,7 @@ describe('jsdoc/src/parser', () => {
             it('should not throw errors when parsing files with ES6 syntax', () => {
                 function parse() {
                     const parserSrc = `javascript:${fs.readFileSync(
-    path.join(jsdoc.env.dirname, 'test/fixtures/es6.js'), 'utf8')}`;
+                        path.join(jsdoc.env.dirname, 'test/fixtures/es6.js'), 'utf8')}`;
 
                     parser.parse(parserSrc);
                 }
@@ -300,7 +300,7 @@ describe('jsdoc/src/parser', () => {
 
             it('should be able to parse its own source file', () => {
                 const parserSrc = `javascript:${fs.readFileSync(path.join(jsdoc.env.dirname,
-    'lib/jsdoc/src/parser.js'), 'utf8')}`;
+                    'lib/jsdoc/src/parser.js'), 'utf8')}`;
 
                 function parse() {
                     parser.parse(parserSrc);

--- a/test/specs/jsdoc/src/scanner.js
+++ b/test/specs/jsdoc/src/scanner.js
@@ -1,9 +1,9 @@
 describe('jsdoc/src/scanner', () => {
-    const env = require('jsdoc/env');
-    const path = require('jsdoc/path');
-    const scanner = require('jsdoc/src/scanner');
+    const env = require('../env');
+    const path = require('../path');
+    const scanner = require('./scanner');
 
-    const filter = new (require('jsdoc/src/filter').Filter)({
+    const filter = new (require('./filter').Filter)({
         includePattern: new RegExp('.+\\.js(doc)?$'),
         excludePattern: new RegExp('(^|\\/|\\\\)_')
     });

--- a/test/specs/jsdoc/src/syntax.js
+++ b/test/specs/jsdoc/src/syntax.js
@@ -1,5 +1,5 @@
 describe('jsdoc/src/syntax', () => {
-    const Syntax = require('jsdoc/src/syntax').Syntax;
+    const Syntax = require('./syntax').Syntax;
 
     it('should exist', () => {
         expect(Syntax).toBeDefined();

--- a/test/specs/jsdoc/src/visitor.js
+++ b/test/specs/jsdoc/src/visitor.js
@@ -3,8 +3,8 @@ describe('jsdoc/src/visitor', () => {
 
     const jsdoc = {
         src: {
-            parser: require('jsdoc/src/parser'),
-            visitor: require('jsdoc/src/visitor')
+            parser: require('./parser'),
+            visitor: require('./visitor')
         }
     };
     const parser = new jsdoc.src.parser.Parser();

--- a/test/specs/jsdoc/src/walker.js
+++ b/test/specs/jsdoc/src/walker.js
@@ -1,5 +1,5 @@
 describe('jsdoc/src/walker', () => {
-    const walker = require('jsdoc/src/walker');
+    const walker = require('./walker');
 
     it('should exist', () => {
         expect(walker).toBeDefined();
@@ -17,7 +17,7 @@ describe('jsdoc/src/walker', () => {
     });
 
     describe('walkers', () => {
-        const Syntax = require('jsdoc/src/syntax').Syntax;
+        const Syntax = require('./syntax').Syntax;
 
         // TODO: tests for default functions
 

--- a/test/specs/jsdoc/tag.js
+++ b/test/specs/jsdoc/tag.js
@@ -2,12 +2,12 @@ const hasOwnProp = Object.prototype.hasOwnProperty;
 
 describe('jsdoc/tag', () => {
     const jsdoc = {
-        env: require('jsdoc/env'),
-        tag: require('jsdoc/tag'),
-        dictionary: require('jsdoc/tag/dictionary'),
-        type: require('jsdoc/tag/type')
+        env: require('../../../lib/jsdoc/env'),
+        tag: require('../../../lib/jsdoc/tag'),
+        dictionary: require('../../../lib/jsdoc/tag/dictionary'),
+        type: require('../../../lib/jsdoc/tag/type')
     };
-    const logger = require('jsdoc/util/logger');
+    const logger = require('../../../lib/jsdoc/util/logger');
 
     it('should exist', () => {
         expect(jsdoc.tag).toBeDefined();

--- a/test/specs/jsdoc/tag/dictionary.js
+++ b/test/specs/jsdoc/tag/dictionary.js
@@ -1,5 +1,5 @@
 describe('jsdoc/tag/dictionary', () => {
-    const dictionary = require('jsdoc/tag/dictionary');
+    const dictionary = require('../../../lib/jsdoc/tag/dictionary');
     const testDictionary = new dictionary.Dictionary();
 
     const tagOptions = {

--- a/test/specs/jsdoc/tag/dictionary/definitions.js
+++ b/test/specs/jsdoc/tag/dictionary/definitions.js
@@ -1,8 +1,8 @@
 describe('jsdoc/tag/dictionary/definitions', () => {
-    const env = require('jsdoc/env');
-    const definitions = require('jsdoc/tag/dictionary/definitions');
-    const Dictionary = require('jsdoc/tag/dictionary').Dictionary;
-    const logger = require('jsdoc/util/logger');
+    const env = require('../../../lib/jsdoc/env');
+    const definitions = require('../../../lib/jsdoc/tag/dictionary/definitions');
+    const Dictionary = require('../../../lib/jsdoc/tag/dictionary').Dictionary;
+    const logger = require('../../../lib/jsdoc/util/logger');
 
     it('should exist', () => {
         expect(definitions).toBeDefined();

--- a/test/specs/jsdoc/tag/inline.js
+++ b/test/specs/jsdoc/tag/inline.js
@@ -1,7 +1,7 @@
 describe('jsdoc/tag/inline', () => {
     const jsdoc = {
         tag: {
-            inline: require('jsdoc/tag/inline')
+            inline: require('../../../lib/jsdoc/tag/inline')
         }
     };
 

--- a/test/specs/jsdoc/tag/type.js
+++ b/test/specs/jsdoc/tag/type.js
@@ -25,7 +25,7 @@ function buildText(type, name, desc) {
 describe('jsdoc/tag/type', () => {
     const jsdoc = {
         tag: {
-            type: require('jsdoc/tag/type')
+            type: require('../../../lib/jsdoc/tag/type')
         }
     };
 

--- a/test/specs/jsdoc/tag/validator.js
+++ b/test/specs/jsdoc/tag/validator.js
@@ -1,9 +1,9 @@
 describe('jsdoc/tag/validator', () => {
-    const doop = require('jsdoc/util/doop');
-    const env = require('jsdoc/env');
-    const logger = require('jsdoc/util/logger');
-    const tag = require('jsdoc/tag');
-    const validator = require('jsdoc/tag/validator');
+    const doop = require('../../../lib/jsdoc/util/doop');
+    const env = require('../../../lib/jsdoc/env');
+    const logger = require('../../../lib/jsdoc/util/logger');
+    const tag = require('../../../lib/jsdoc/tag');
+    const validator = require('../../../lib/jsdoc/tag/validator');
 
     it('should exist', () => {
         expect(validator).toBeDefined();
@@ -16,7 +16,7 @@ describe('jsdoc/tag/validator', () => {
     });
 
     describe('validate', () => {
-        const dictionary = require('jsdoc/tag/dictionary');
+        const dictionary = require('../../../lib/jsdoc/tag/dictionary');
 
         const allowUnknown = Boolean(env.conf.tags.allowUnknownTags);
         const badTag = { title: 'lkjasdlkjfb' };

--- a/test/specs/jsdoc/tutorial.js
+++ b/test/specs/jsdoc/tutorial.js
@@ -1,6 +1,6 @@
 describe('jsdoc/tutorial', () => {
-    const env = require('jsdoc/env');
-    const tutorial = require('jsdoc/tutorial');
+    const env = require('../../../lib/jsdoc/env');
+    const tutorial = require('../../../lib/jsdoc/tutorial');
 
     const name = 'tuteID';
     const content = 'Tutorial content blah blah blah & <';

--- a/test/specs/jsdoc/tutorial/resolver.js
+++ b/test/specs/jsdoc/tutorial/resolver.js
@@ -1,8 +1,8 @@
 describe('jsdoc/tutorial/resolver', () => {
-    const env = require('jsdoc/env');
-    const logger = require('jsdoc/util/logger');
-    const resolver = require('jsdoc/tutorial/resolver');
-    const tutorial = require('jsdoc/tutorial');
+    const env = require('../../../lib/jsdoc/env');
+    const logger = require('../../../lib/jsdoc/util/logger');
+    const resolver = require('../../../lib/jsdoc/tutorial/resolver');
+    const tutorial = require('../../../lib/jsdoc/tutorial');
 
     let childNames;
     let constr;

--- a/test/specs/jsdoc/util/cast.js
+++ b/test/specs/jsdoc/util/cast.js
@@ -1,5 +1,5 @@
 describe('jsdoc/util/cast', () => {
-    const cast = require('jsdoc/util/cast');
+    const cast = require('../../../lib/jsdoc/util/cast');
 
     it('should exist', () => {
         expect(typeof cast).toBe('object');

--- a/test/specs/jsdoc/util/doop.js
+++ b/test/specs/jsdoc/util/doop.js
@@ -1,5 +1,5 @@
 describe('jsdoc/util/doop', () => {
-    const doop = require('jsdoc/util/doop');
+    const doop = require('../../../lib/jsdoc/util/doop');
 
     it('should exist', () => {
         expect(doop).toBeDefined();

--- a/test/specs/jsdoc/util/dumper.js
+++ b/test/specs/jsdoc/util/dumper.js
@@ -1,5 +1,5 @@
 describe('jsdoc/util/dumper', () => {
-    const dumper = require('jsdoc/util/dumper');
+    const dumper = require('../../../lib/jsdoc/util/dumper');
 
     it('should exist', () => {
         expect(dumper).toBeDefined();

--- a/test/specs/jsdoc/util/error.js
+++ b/test/specs/jsdoc/util/error.js
@@ -1,7 +1,7 @@
 describe('jsdoc/util/error', () => {
-    const error = require('jsdoc/util/error');
+    const error = require('../../../lib/jsdoc/util/error');
     const handle = error.handle;
-    const logger = require('jsdoc/util/logger');
+    const logger = require('../../../lib/jsdoc/util/logger');
 
     it('should exist', () => {
         expect(error).toBeDefined();

--- a/test/specs/jsdoc/util/logger.js
+++ b/test/specs/jsdoc/util/logger.js
@@ -1,5 +1,5 @@
 describe('jsdoc/util/logger', () => {
-    const logger = require('jsdoc/util/logger');
+    const logger = require('../../../lib/jsdoc/util/logger');
 
     const loggerArgs = ['foo bar %s', 'hello'];
 

--- a/test/specs/jsdoc/util/markdown.js
+++ b/test/specs/jsdoc/util/markdown.js
@@ -1,7 +1,7 @@
 describe('jsdoc/util/markdown', () => {
-    const env = require('jsdoc/env');
-    const logger = require('jsdoc/util/logger');
-    const markdown = require('jsdoc/util/markdown');
+    const env = require('../../../lib/jsdoc/env');
+    const logger = require('../../../lib/jsdoc/util/logger');
+    const markdown = require('../../../lib/jsdoc/util/markdown');
 
     it('should exist', () => {
         expect(markdown).toBeDefined();

--- a/test/specs/jsdoc/util/stripbom.js
+++ b/test/specs/jsdoc/util/stripbom.js
@@ -1,5 +1,5 @@
 describe('jsdoc/util/stripbom', () => {
-    const stripBom = require('jsdoc/util/stripbom');
+    const stripBom = require('../../../lib/jsdoc/util/stripbom');
 
     it('should exist', () => {
         expect(typeof stripBom).toBe('object');

--- a/test/specs/jsdoc/util/templateHelper.js
+++ b/test/specs/jsdoc/util/templateHelper.js
@@ -2,14 +2,14 @@
 const hasOwnProp = Object.prototype.hasOwnProperty;
 
 describe("jsdoc/util/templateHelper", () => {
-    const definitions = require('jsdoc/tag/dictionary/definitions');
-    const dictionary = require('jsdoc/tag/dictionary');
-    const doclet = require('jsdoc/doclet');
-    const doop = require('jsdoc/util/doop');
-    const env = require('jsdoc/env');
-    const helper = require('jsdoc/util/templateHelper');
-    const logger = require('jsdoc/util/logger');
-    const resolver = require('jsdoc/tutorial/resolver');
+    const definitions = require('../../../lib/jsdoc/tag/dictionary/definitions');
+    const dictionary = require('../../../lib/jsdoc/tag/dictionary');
+    const doclet = require('../../../lib/jsdoc/doclet');
+    const doop = require('../../../lib/jsdoc/util/doop');
+    const env = require('../../../lib/jsdoc/env');
+    const helper = require('../../../lib/jsdoc/util/templateHelper');
+    const logger = require('../../../lib/jsdoc/util/logger');
+    const resolver = require('../../../lib/jsdoc/tutorial/resolver');
     const taffy = require('taffydb').taffy;
 
     helper.registerLink('test', 'path/to/test.html');

--- a/test/specs/plugins/plugins.js
+++ b/test/specs/plugins/plugins.js
@@ -1,8 +1,8 @@
 // TODO: consolidate with specs/jsdoc/parser and specs/jsdoc/plugins
 describe('plugins', () => {
-    const app = require('jsdoc/app');
-    const env = require('jsdoc/env');
-    const path = require('jsdoc/path');
+    const app = require('../../../lib/jsdoc/app');
+    const env = require('../../../lib/jsdoc/env');
+    const path = require('../../../lib/jsdoc/path');
 
     let docSet;
     const pluginPaths = [
@@ -15,7 +15,7 @@ describe('plugins', () => {
 
     global.jsdocPluginsTest = global.jsdocPluginsTest || {};
 
-    require('jsdoc/plugins').installPlugins(pluginPaths, app.jsdoc.parser);
+    require('../../../lib/jsdoc/plugins').installPlugins(pluginPaths, app.jsdoc.parser);
 
     docSet = jasmine.getDocSetFromFile('test/fixtures/plugins.js', app.jsdoc.parser, false);
 

--- a/test/specs/tags/borrowstag.js
+++ b/test/specs/tags/borrowstag.js
@@ -13,7 +13,7 @@ describe('@borrows tag', () => {
     });
 
     it('When a symbol has a @borrows tag, the borrowed symbol is added to the symbol.', () => {
-        const borrow = require('jsdoc/borrow');
+        const borrow = require('../../../lib/jsdoc/borrow');
         const docSet = jasmine.getDocSetFromFile('test/fixtures/borrowstag2.js');
 
         borrow.resolveBorrows(docSet.doclets);

--- a/test/specs/tags/definetag.js
+++ b/test/specs/tags/definetag.js
@@ -1,8 +1,8 @@
 describe('@define tag', () => {
-    const logger = require('jsdoc/util/logger');
+    const logger = require('../../../lib/jsdoc/util/logger');
 
     describe('JSDoc tags', () => {
-        const env = require('jsdoc/env');
+        const env = require('../../../lib/jsdoc/env');
 
         const allowUnknownTags = Boolean(env.conf.tags.allowUnknownTags);
 

--- a/test/specs/tags/dicttag.js
+++ b/test/specs/tags/dicttag.js
@@ -1,6 +1,6 @@
 describe('@dict tag', () => {
-    const env = require('jsdoc/env');
-    const logger = require('jsdoc/util/logger');
+    const env = require('../../../lib/jsdoc/env');
+    const logger = require('../../../lib/jsdoc/util/logger');
 
     const allowUnknownTags = Boolean(env.conf.tags.allowUnknownTags);
 

--- a/test/specs/tags/enumtag.js
+++ b/test/specs/tags/enumtag.js
@@ -24,7 +24,7 @@ describe('@enum tag', () => {
     });
 
     it('An enum does not contain any circular references.', () => {
-        const dump = require('jsdoc/util/dumper').dump;
+        const dump = require('../../../lib/jsdoc/util/dumper').dump;
 
         expect( dump(tristate) ).not.toMatch('<CircularRef>');
     });

--- a/test/specs/tags/exporttag.js
+++ b/test/specs/tags/exporttag.js
@@ -1,6 +1,6 @@
 describe('@export tag', () => {
-    const env = require('jsdoc/env');
-    const logger = require('jsdoc/util/logger');
+    const env = require('../../../lib/jsdoc/env');
+    const logger = require('../../../lib/jsdoc/util/logger');
 
     const allowUnknownTags = Boolean(env.conf.tags.allowUnknownTags);
 

--- a/test/specs/tags/externstag.js
+++ b/test/specs/tags/externstag.js
@@ -1,6 +1,6 @@
 describe('@externs tag', () => {
-    const env = require('jsdoc/env');
-    const logger = require('jsdoc/util/logger');
+    const env = require('../../../lib/jsdoc/env');
+    const logger = require('../../../lib/jsdoc/util/logger');
 
     const allowUnknownTags = Boolean(env.conf.tags.allowUnknownTags);
 

--- a/test/specs/tags/implicitcasttag.js
+++ b/test/specs/tags/implicitcasttag.js
@@ -1,6 +1,6 @@
 describe('@implicitCast tag', () => {
-    const env = require('jsdoc/env');
-    const logger = require('jsdoc/util/logger');
+    const env = require('../../../lib/jsdoc/env');
+    const logger = require('../../../lib/jsdoc/util/logger');
 
     const allowUnknownTags = Boolean(env.conf.tags.allowUnknownTags);
 

--- a/test/specs/tags/interfacetag.js
+++ b/test/specs/tags/interfacetag.js
@@ -1,5 +1,5 @@
 describe('@interface tag', () => {
-    const logger = require('jsdoc/util/logger');
+    const logger = require('../../../lib/jsdoc/util/logger');
 
     const docSet = jasmine.getDocSetFromFile('test/fixtures/interface-implements.js');
     const testerInterface = docSet.getByLongname('ITester')[0];

--- a/test/specs/tags/lendstag.js
+++ b/test/specs/tags/lendstag.js
@@ -1,6 +1,6 @@
 describe('@lends tag', () => {
     // see also specs/documentation/lends.js for tests on @lends behaviour.
-    const doclet = require('jsdoc/doclet');
+    const doclet = require('../../../lib/jsdoc/doclet');
 
     const doc = new doclet.Doclet('/** @lends */', {});
     const doc2 = new doclet.Doclet('/** @lends MyClass# */', {});

--- a/test/specs/tags/noaliastag.js
+++ b/test/specs/tags/noaliastag.js
@@ -1,6 +1,6 @@
 describe('@noalias tag', () => {
-    const env = require('jsdoc/env');
-    const logger = require('jsdoc/util/logger');
+    const env = require('../../../lib/jsdoc/env');
+    const logger = require('../../../lib/jsdoc/util/logger');
 
     const allowUnknownTags = Boolean(env.conf.tags.allowUnknownTags);
 

--- a/test/specs/tags/nocollapsetag.js
+++ b/test/specs/tags/nocollapsetag.js
@@ -1,6 +1,6 @@
 describe('@nocollapse tag', () => {
-    const env = require('jsdoc/env');
-    const logger = require('jsdoc/util/logger');
+    const env = require('../../../lib/jsdoc/env');
+    const logger = require('../../../lib/jsdoc/util/logger');
 
     const allowUnknownTags = Boolean(env.conf.tags.allowUnknownTags);
 

--- a/test/specs/tags/nocompiletag.js
+++ b/test/specs/tags/nocompiletag.js
@@ -1,6 +1,6 @@
 describe('@nocompile tag', () => {
-    const env = require('jsdoc/env');
-    const logger = require('jsdoc/util/logger');
+    const env = require('../../../lib/jsdoc/env');
+    const logger = require('../../../lib/jsdoc/util/logger');
 
     const allowUnknownTags = Boolean(env.conf.tags.allowUnknownTags);
 

--- a/test/specs/tags/overviewtag.js
+++ b/test/specs/tags/overviewtag.js
@@ -1,6 +1,6 @@
 describe('@overview tag', () => {
-    const env = require('jsdoc/env');
-    const path = require('jsdoc/path');
+    const env = require('../../../lib/jsdoc/env');
+    const path = require('../../../lib/jsdoc/path');
 
     let doclets;
 
@@ -14,7 +14,7 @@ describe('@overview tag', () => {
         env.pwd = env.dirname;
         env.sourceFiles = [];
         srcParser = jasmine.createParser();
-        require('jsdoc/src/handlers').attachTo(srcParser);
+        require('../../../lib/jsdoc/src/handlers').attachTo(srcParser);
     });
 
     afterEach(() => {
@@ -45,7 +45,7 @@ describe('@overview tag', () => {
 
     it('The name should not include the entire filepath when the source file is outside the ' +
         'JSDoc directory', () => {
-        const Doclet = require('jsdoc/doclet').Doclet;
+        const Doclet = require('../../../lib/jsdoc/doclet').Doclet;
         const os = require('os');
 
         let doclet;

--- a/test/specs/tags/packagetag.js
+++ b/test/specs/tags/packagetag.js
@@ -1,4 +1,4 @@
-const logger = require('jsdoc/util/logger');
+const logger = require('../../../lib/jsdoc/util/logger');
 
 describe('@package tag', () => {
     const docSet = jasmine.getDocSetFromFile('test/fixtures/packagetag.js');

--- a/test/specs/tags/polymerbehaviortag.js
+++ b/test/specs/tags/polymerbehaviortag.js
@@ -1,6 +1,6 @@
 describe('@polymerBehavior tag', () => {
-    const env = require('jsdoc/env');
-    const logger = require('jsdoc/util/logger');
+    const env = require('../../../lib/jsdoc/env');
+    const logger = require('../../../lib/jsdoc/util/logger');
 
     const allowUnknownTags = Boolean(env.conf.tags.allowUnknownTags);
 

--- a/test/specs/tags/polymertag.js
+++ b/test/specs/tags/polymertag.js
@@ -1,6 +1,6 @@
 describe('@polymer tag', () => {
-    const env = require('jsdoc/env');
-    const logger = require('jsdoc/util/logger');
+    const env = require('../../../lib/jsdoc/env');
+    const logger = require('../../../lib/jsdoc/util/logger');
 
     const allowUnknownTags = Boolean(env.conf.tags.allowUnknownTags);
 

--- a/test/specs/tags/preservetag.js
+++ b/test/specs/tags/preservetag.js
@@ -1,6 +1,6 @@
 describe('@preserve tag', () => {
-    const env = require('jsdoc/env');
-    const logger = require('jsdoc/util/logger');
+    const env = require('../../../lib/jsdoc/env');
+    const logger = require('../../../lib/jsdoc/util/logger');
 
     const allowUnknownTags = Boolean(env.conf.tags.allowUnknownTags);
 

--- a/test/specs/tags/privatetag.js
+++ b/test/specs/tags/privatetag.js
@@ -1,4 +1,4 @@
-const logger = require('jsdoc/util/logger');
+const logger = require('../../../lib/jsdoc/util/logger');
 
 describe('@private tag', () => {
     const docSet = jasmine.getDocSetFromFile('test/fixtures/privatetag.js');

--- a/test/specs/tags/protectedtag.js
+++ b/test/specs/tags/protectedtag.js
@@ -1,4 +1,4 @@
-const logger = require('jsdoc/util/logger');
+const logger = require('../../../lib/jsdoc/util/logger');
 
 describe('@protected tag', () => {
     const docSet = jasmine.getDocSetFromFile('test/fixtures/protectedtag.js');

--- a/test/specs/tags/structtag.js
+++ b/test/specs/tags/structtag.js
@@ -1,6 +1,6 @@
 describe('@struct tag', () => {
-    const env = require('jsdoc/env');
-    const logger = require('jsdoc/util/logger');
+    const env = require('../../../lib/jsdoc/env');
+    const logger = require('../../../lib/jsdoc/util/logger');
 
     const allowUnknownTags = Boolean(env.conf.tags.allowUnknownTags);
 

--- a/test/specs/tags/suppresstag.js
+++ b/test/specs/tags/suppresstag.js
@@ -1,6 +1,6 @@
 describe('@suppress tag', () => {
-    const env = require('jsdoc/env');
-    const logger = require('jsdoc/util/logger');
+    const env = require('../../../lib/jsdoc/env');
+    const logger = require('../../../lib/jsdoc/util/logger');
 
     const allowUnknownTags = Boolean(env.conf.tags.allowUnknownTags);
 

--- a/test/specs/tags/templatetag.js
+++ b/test/specs/tags/templatetag.js
@@ -1,6 +1,6 @@
 describe('@template tag', () => {
-    const env = require('jsdoc/env');
-    const logger = require('jsdoc/util/logger');
+    const env = require('../../../lib/jsdoc/env');
+    const logger = require('../../../lib/jsdoc/util/logger');
 
     const allowUnknownTags = Boolean(env.conf.tags.allowUnknownTags);
 

--- a/test/specs/tags/typetag.js
+++ b/test/specs/tags/typetag.js
@@ -1,4 +1,4 @@
-const logger = require('jsdoc/util/logger');
+const logger = require('../../../lib/jsdoc/util/logger');
 
 describe('@type tag', () => {
     const docSet = jasmine.getDocSetFromFile('test/fixtures/typetag.js');

--- a/test/specs/tags/unrestrictedtag.js
+++ b/test/specs/tags/unrestrictedtag.js
@@ -1,6 +1,6 @@
 describe('@unrestricted tag', () => {
-    const env = require('jsdoc/env');
-    const logger = require('jsdoc/util/logger');
+    const env = require('../../../lib/jsdoc/env');
+    const logger = require('../../../lib/jsdoc/util/logger');
 
     const allowUnknownTags = Boolean(env.conf.tags.allowUnknownTags);
 


### PR DESCRIPTION
This is an attempt to get the JSDoc project running on Node > 10 (see hegemonic/requizzle#6 for background).

Clearly this is a breaking change.  Ideally it would be accompanied by other changes to remove deprecated things and update the code with the aim of making it more maintainable (by more people).

I'm putting this up as a draft pull request to solicit feedback.  So far, the breaking changes include:

 * if plugins `require` modules from JSDoc, they need to use the full path (e.g. `jsdoc/lib/jsdoc/env` instead of `jsdoc/env`)
 * the values in the `plugins` array of a `conf.json` are paths to plugins (e.g. `node_modules/some-plugin` or `some/local/plugin`)

It would be possible to maintain the old require paths by restructuring the published package or the repo itself.

It should also be possible to support lookup of plugins in `node_modules`, but I didn't do that here.