### PR TITLE
Highlight multiple line when redirecting to a file#line

### DIFF
--- a/templates/default/static/scripts/linenumber.js
+++ b/templates/default/static/scripts/linenumber.js
@@ -7,9 +7,15 @@
     let lines;
     let totalLines;
     let anchorHash;
+    let from;
+    let to;
 
     if (source && source[0]) {
         anchorHash = document.location.hash.substring(1);
+        if (anchorHash.indexOf("to") != -1) {
+            from = anchorHash.split('to')[0].split('line')[1];
+            to = anchorHash.split('to')[1];
+        }
         lines = source[0].getElementsByTagName('li');
         totalLines = lines.length;
 
@@ -17,7 +23,7 @@
             lineNumber++;
             lineId = `line${lineNumber}`;
             lines[i].id = lineId;
-            if (lineId === anchorHash) {
+            if (lineId === anchorHash || (lineNumber >= parseInt(from) && lineNumber <= parseInt(to))) {
                 lines[i].className += ' selected';
             }
         }


### PR DESCRIPTION
Add the possibility to create multiple lines highlight to a file and line number by using <a href='yourfile.example#lineXtoY' (x is the first line and y the last one to highlight).

Usefull if you want to highlight a region more than a single line.

<!--
Before creating a pull request, please read our contributing guidelines and code of conduct:

https://github.com/jsdoc3/jsdoc/blob/master/CONTRIBUTING.md
https://github.com/jsdoc3/jsdoc/blob/master/CODE_OF_CONDUCT.md
-->

| Q                | A
| ---------------- | ---
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Deprecations?    | no
| Tests added?     | no
| Fixed issues     | comma-separated list of issues fixed by the pull request, if any
| License          | Apache-2.0

<!-- Describe your changes below in as much detail as possible. -->
