### PR TITLE
feat: allow plugins to be used from the command line 

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -319,6 +319,11 @@ module.exports = (() => {
             plugins.installPlugins(env.conf.plugins, props.parser);
         }
 
+        if (env.opts.plugins) {
+            env.conf.plugins = resolvePluginPaths(env.opts.plugins);
+            plugins.installPlugins(env.opts.plugins, props.parser);
+        }
+
         handlers.attachTo(props.parser);
 
         return cli;

--- a/lib/jsdoc/opts/args.js
+++ b/lib/jsdoc/opts/args.js
@@ -36,6 +36,7 @@ argParser.addOption('u', 'tutorials',   true,  'Directory in which JSDoc should 
 argParser.addOption('v', 'version',     false, 'Display the version number and quit.');
 argParser.addOption('',  'verbose',     false, 'Log detailed information to the console as JSDoc runs.');
 argParser.addOption('X', 'explain',     false, 'Dump all found doclet internals to console and quit.');
+argParser.addOption('g',  'plugin',     true,  'Use this plugin during generation, can be passed multiple times', true);
 /* eslint-enable no-multi-spaces */
 
 // Options that are no longer supported and should be ignored

--- a/test/specs/jsdoc/opts/args.js
+++ b/test/specs/jsdoc/opts/args.js
@@ -295,6 +295,36 @@ describe('jsdoc/opts/args', () => {
             expect(args.get()._).toEqual(['myfile1', 'myfile2']);
         });
 
+        it('should accept a "-g" option and return an object with a "plugin" property', function() {
+            args.parse(['-g', 'plugin/test']);
+            var r = args.get();
+
+            expect(r.plugin).toBe('plugin/test');
+        });
+
+        it('should accept multiple "-g" options and return an object with a "plugin" property', function() {
+            args.parse(['-g', 'plugin/test', '-g', 'plugin/test2']);
+            var r = args.get();
+
+            expect(r.plugin[0]).toBe('plugin/test');
+            expect(r.plugin[1]).toBe('plugin/test2');
+        });
+
+        it('should accept a "--plugin" option and return an object with a "plugin" property', function() {
+            args.parse(['--plugin', 'plugin/test']);
+            var r = args.get();
+
+            expect(r.plugin).toBe('plugin/test');
+        });
+
+        it('should accept multiple "--plugin" options and return an object with a "plugin" property', function() {
+            args.parse(['--plugin', 'plugin/test', '--plugin', 'plugin/test2']);
+            var r = args.get();
+
+            expect(r.plugin[0]).toBe('plugin/test');
+            expect(r.plugin[1]).toBe('plugin/test2');
+        });
+
         // TODO: tests for args that must have values
     });
 });


### PR DESCRIPTION
<!--
Before creating a pull request, please read our contributing guidelines and code of conduct:

https://github.com/jsdoc3/jsdoc/blob/master/CONTRIBUTING.md
https://github.com/jsdoc3/jsdoc/blob/master/CODE_OF_CONDUCT.md
-->

| Q                | A
| ---------------- | ---
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Deprecations?    | no
| Tests added?     | yes
| Fixed issues     | 
| License          | Apache-2.0

<!-- Describe your changes below in as much detail as possible. -->
We use jsdoc for most of our projects, but since we cannot use plugins from the command line we are forced to have the same boilerplate config for each:
```json
{
  "plugins": ["plugins/markdown"]
}
```

It would be much nicer if we could just pass them from the command line. So I implemented this feature. I am not sure if the argument should be called `-g` or `--plugin` but I think the general jist of this feature is here and will be happy to change the argument names as required.

Originally opened as #1561 but rebased on master, and some of our internal code is using my branch.
