### PR TITLE
Improve sementic `div > {nodeText}` to `div > p > {nodeText}`

### DIFF
--- a/templates/default/tmpl/container.tmpl
+++ b/templates/default/tmpl/container.tmpl
@@ -30,12 +30,12 @@
             <sup class="variation"><?js= doc.variation ?></sup><?js }
          if (doc.signature && !doc.hideconstructor) { ?><?js= doc.signature ?><?js } ?></h2>
         <?js if (doc.classdesc) { ?>
-            <div class="class-description"><?js= doc.classdesc ?></div>
+            <div class="class-description"><p><?js= doc.classdesc ?></p></div>
         <?js } ?>
     <?js } else if (doc.kind === 'module' && doc.modules) { ?>
         <?js doc.modules.forEach(function(module) { ?>
             <?js if (module.classdesc) { ?>
-                <div class="class-description"><?js= module.classdesc ?></div>
+                <div class="class-description"><p><?js= module.classdesc ?></p></div>
             <?js } ?>
         <?js }) ?>
     <?js } ?>
@@ -45,7 +45,7 @@
     <div class="container-overview">
     <?js if (doc.kind === 'module' && doc.modules) { ?>
         <?js if (doc.description) { ?>
-            <div class="description"><?js= doc.description ?></div>
+            <div class="description"><p><?js= doc.description ?></p></div>
         <?js } ?>
 
         <?js doc.modules.forEach(function(module) { ?>
@@ -55,7 +55,7 @@
         <?js= self.partial('method.tmpl', doc) ?>
     <?js } else { ?>
         <?js if (doc.description) { ?>
-            <div class="description"><?js= doc.description ?></div>
+            <div class="description"><p><?js= doc.description ?></p></div>
         <?js } ?>
 
         <?js= self.partial('details.tmpl', doc) ?>

--- a/templates/default/tmpl/exceptions.tmpl
+++ b/templates/default/tmpl/exceptions.tmpl
@@ -5,7 +5,7 @@
 <dl>
     <dt>
         <div class="param-desc">
-        <?js= data.description ?>
+            <p><?js= data.description ?></p>
         </div>
     </dt>
     <dd></dd>
@@ -23,10 +23,12 @@
 </dl>
 <?js } else { ?>
     <div class="param-desc">
-    <?js if (data.description) { ?>
-        <?js= data.description ?>
-    <?js } else if (data.type && data.type.names) { ?>
-        <?js= this.partial('type.tmpl', data.type.names) ?>
-    <?js } ?>
+        <p>
+        <?js if (data.description) { ?>
+            <?js= data.description ?>
+        <?js } else if (data.type && data.type.names) { ?>
+            <?js= this.partial('type.tmpl', data.type.names) ?>
+        <?js } ?>
+        </p>
     </div>
 <?js } ?>

--- a/templates/default/tmpl/members.tmpl
+++ b/templates/default/tmpl/members.tmpl
@@ -10,7 +10,7 @@ var self = this;
 
 <?js if (data.description) { ?>
 <div class="description">
-    <?js= data.description ?>
+    <p><?js= data.description ?></p>
 </div>
 <?js } ?>
 

--- a/templates/default/tmpl/method.tmpl
+++ b/templates/default/tmpl/method.tmpl
@@ -19,7 +19,7 @@ var self = this;
 
 <?js if (data.kind !== 'module' && data.description && !data.hideconstructor) { ?>
 <div class="description">
-    <?js= data.description ?>
+    <p><?js= data.description ?></p>
 </div>
 <?js } ?>
 

--- a/templates/default/tmpl/returns.tmpl
+++ b/templates/default/tmpl/returns.tmpl
@@ -3,7 +3,7 @@ var data = obj || {};
 if (data.description) {
 ?>
 <div class="param-desc">
-    <?js= description ?>
+    <p><?js= description ?></p>
 </div>
 <?js } ?>
 


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Deprecations?    | no
| Tests added?     | no
| Fixed issues     | -

Improve sementic `div > {nodeText}` to `div > p > {nodeText}`. According to: https://stackoverflow.com/a/2226574/2226755 elements should be : `div > p > {nodeText}` 


This make **no visual** change is **only semantic**, you can check this : [before](https://user-images.githubusercontent.com/18501150/64691186-6a956480-d492-11e9-850e-e6087d2a8aac.png) / [after](https://user-images.githubusercontent.com/18501150/64691161-57829480-d492-11e9-9f92-86d5fbe33377.png)



# Q/A

Check the doc page, you should see no difference in the render.
