### PR TITLE
Fix broken template example link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ and customize your documentation. Here are a few of them:
 + [docdash](https://github.com/clenemt/docdash)
 ([example](http://clenemt.github.io/docdash/))
 + [tui-jsdoc-template](https://github.com/nhnent/tui.jsdoc-template)
-([example](https://nhnent.github.io/tui.jsdoc-template/latest/))
+([example](https://nhn.github.io/tui.jsdoc-template/latest/))
 + [better-docs](https://github.com/SoftwareBrothers/better-docs)
 ([example](https://softwarebrothers.github.io/admin-bro-dev/index.html))
 


### PR DESCRIPTION
<!--
Before creating a pull request, please read our contributing guidelines and code of conduct:

https://github.com/jsdoc3/jsdoc/blob/master/CONTRIBUTING.md
https://github.com/jsdoc3/jsdoc/blob/master/CODE_OF_CONDUCT.md
-->

| Q                | A
| ---------------- | ---
| Bug fix?         | no (?)
| New feature?     | no
| Breaking change? | no
| Deprecations?    | no
| Tests added?     | no
| Fixed issues     | 
| License          | Apache-2.0

<!-- Describe your changes below in as much detail as possible. -->

The [original link](https://nhnent.github.io/tui.jsdoc-template/latest/) to the example of the "tui-jsdoc" template was incorrect and went to a 404 page - it has now been updated with [the correct link](https://nhn.github.io/tui.jsdoc-template/latest/).