### PR TITLE
docs: Add missing and update JSDoc comments (fix #839)

### DIFF
--- a/packages/jsdoc-core/lib/config.js
+++ b/packages/jsdoc-core/lib/config.js
@@ -1,7 +1,7 @@
 /**
  * Manages configuration settings for JSDoc.
  *
- * @alias module:@jsdoc/core.config
+ * @alias module:'@jsdoc/core.config'
  */
 
 const _ = require('lodash');
@@ -91,10 +91,24 @@ class Config {
     }
 }
 
+/**
+ *  Loads JSON using cosmiconfig.
+ *
+ *  @param {string} filepath - The path to the JSON file.
+ *  @param {string} content  - The file’s content. (Filtered to strip JSON comments and BOM characters.)
+ *  @returns {object} - The configuration object.
+ */
 function loadJson(filepath, content) {
     return cosmiconfig.loadJson(filepath, stripBom(stripJsonComments(content)));
 }
 
+/**
+ *  Loads JSON using `cosmiconfig`.
+ *
+ *  @param {string} filepath - The path to the YAML file.
+ *  @param {string} content - The file’s content. (Filtered to strip BOM characters.)
+ *  @returns {object} - The configuration object.
+ */
 function loadYaml(filepath, content) {
     return cosmiconfig.loadYaml(filepath, stripBom(content));
 }

--- a/packages/jsdoc-core/lib/engine/flags.js
+++ b/packages/jsdoc-core/lib/engine/flags.js
@@ -5,7 +5,7 @@ const querystring = require('querystring');
 /**
  * Command-line flags recognized by JSDoc.
  *
- * @alias module:@jsdoc/core/lib/engine/flags
+ * @alias module:'@jsdoc/core/lib/engine/flags'
  */
 module.exports = {
     access: {

--- a/packages/jsdoc-core/lib/engine/help.js
+++ b/packages/jsdoc-core/lib/engine/help.js
@@ -1,13 +1,33 @@
 const flags = require('./flags');
 
+/**
+ * Pads the start of `str` with `length` spaces.
+ *
+ * @param {string} str    - The string to pad.
+ * @param {number} length - The number of spaces to add to the start of `str`.
+ * @returns {string} The padded string.
+ */
 function padLeft(str, length) {
     return str.padStart(str.length + length);
 }
 
+/**
+ * Pads the end of `str` with `length` spaces.
+ *
+ * @param {string} str    - The string to pad.
+ * @param {number} length - The number of spaces to add to the end of `str`.
+ * @returns {string} The padded string.
+ */
 function padRight(str, length) {
     return str.padEnd(str.length + length);
 }
 
+/**
+ * Finds the highest `length` value of every object in `arr`.
+ *
+ * @param {Array} arr - The array to search.
+ * @returns {number} The highest value found from each object’s `length` property within `arr`.
+ */
 function findMaxLength(arr) {
     let max = 0;
 
@@ -18,6 +38,14 @@ function findMaxLength(arr) {
     return max;
 }
 
+/**
+ * Concatenates (in order) the values of `items`. If any value exceeds `maxLength`,
+ * concatenation stops and the result is returned.
+ *
+ * @param {Array} items      - The list of values to concatenate.
+ * @param {number} maxLength - The maximum length allowed for concatenation to continue.
+ * @returns {string} The concatenated result.
+ */
 function concatWithMaxLength(items, maxLength) {
     let result = '';
 
@@ -41,12 +69,13 @@ function concatWithMaxLength(items, maxLength) {
  * |    --bar        This description is not as long.                         |
  * ```
  *
- * @param {Object} flagInfo - Information about each known flag.
- * @param {Array<string>} flagInfo.names - An array of known flag names.
- * @param {Array<string>} flagInfo.descriptions - An array of descriptions for each known flag, in
+ * @param {object} flagInfo - Information about each known flag.
+ * @param {Array.<string>} flagInfo.names - An array of known flag names.
+ * @param {Array.<string>} flagInfo.descriptions - An array of descriptions for each known flag, in
  * the same order as `flagInfo.names`.
- * @param {Object} opts - Options for formatting the text.
+ * @param {object} opts - Options for formatting the text.
  * @param {number} opts.maxLength - The maximum length of each line.
+ * @returns {Array.<string>} The list of formatted strings.
  */
 function formatHelpInfo({names, descriptions}, {maxLength}) {
     const MARGIN_SIZE = 4;
@@ -88,10 +117,10 @@ function formatHelpInfo({names, descriptions}, {maxLength}) {
 /**
  * Get a formatted version of the help text for JSDoc.
  *
- * @alias module:@jsdoc/core/lib/engine/help
- * @param {Object} opts - Options for formatting the help text.
+ * @alias module:'@jsdoc/core/lib/engine/help'
+ * @param {object} opts - Options for formatting the help text.
  * @param {number} opts.maxLength - The maximum length of each line in the formatted text.
- * @return {string} The formatted help text.
+ * @returns {string} The formatted help text.
  * @private
  */
 module.exports = ({ maxLength }) => {

--- a/packages/jsdoc-core/lib/engine/index.js
+++ b/packages/jsdoc-core/lib/engine/index.js
@@ -4,6 +4,13 @@ const help = require('./help');
 const ow = require('ow');
 const yargs = require('yargs-parser');
 
+/**
+ * Validates a command-line flag for the command-line interface (CLI).
+ *
+ * @param {object} flagInfo        - Contains info about the command-line flag.
+ * @param {Array.<string>} choices - A list of acceptable choices for the flag.
+ * @param {Array.<string>} values  - A list of values passed to the flag.
+ */
 function validateChoice(flagInfo, choices, values) {
     let flagNames = flagInfo.alias ? `-${flagInfo.alias}/` : '';
 
@@ -81,13 +88,13 @@ const { KNOWN_FLAGS, YARGS_FLAGS } = (() => {
 /**
  * CLI engine for JSDoc.
  *
- * @alias module:@jsdoc/core.Engine
+ * @alias module:'@jsdoc/core.Engine'
  */
 class Engine {
     /**
      * Create an instance of the CLI engine.
      *
-     * @param {Object} opts - Options for the CLI engine.
+     * @param {object} opts - Options for the CLI engine.
      * @param {string} [opts.version] - The version of JSDoc that is running.
      * @param {Date} [opts.revision] - A timestamp for the version of JSDoc that is running.
      */
@@ -108,10 +115,10 @@ class Engine {
      * line within the maximum length, but it only splits on word boundaries. If you specify a small
      * length, such as `10`, some lines will exceed that length.
      *
-     * @param {Object} [opts] - Options for formatting the help text.
+     * @param {object} [opts] - Options for formatting the help text.
      * @param {number} [opts.maxLength=Infinity] - The desired maximum length of each line in the
      * formatted text.
-     * @return {string} The formatted help text.
+     * @returns {string} The formatted help text.
      */
     help(opts = {}) {
         ow(opts, ow.object);
@@ -127,6 +134,8 @@ class Engine {
 
     /**
      * Details about the command-line flags that JSDoc recognizes.
+     *
+     * @returns {object} Recognized flags (with details!).
      */
     get knownFlags() {
         return flags;
@@ -137,8 +146,8 @@ class Engine {
      *
      * Use the instance's `flags` property to retrieve the parsed flags later.
      *
-     * @param {Array<string>} cliFlags - The command-line flags to parse.
-     * @returns {Object} The name and value for each flag. The `_` property contains all arguments
+     * @param {Array.<string>} cliFlags - The command-line flags to parse.
+     * @returns {object} The name and value for each flag. The `_` property contains all arguments
      * other than flags and their values.
      */
     parseFlags(cliFlags) {
@@ -187,6 +196,8 @@ class Engine {
 
     /**
      * A string that describes the current JSDoc version.
+     *
+     * @returns {string} JSDoc’s version string.
      */
     get versionDetails() {
         let revision = '';

--- a/packages/jsdoc-core/lib/util/cast.js
+++ b/packages/jsdoc-core/lib/util/cast.js
@@ -1,7 +1,7 @@
 /**
  * Module to convert values between various JavaScript types.
  *
- * @alias module:@jsdoc/core.util.cast
+ * @alias module:'@jsdoc/core.util.cast'
  */
 
 /**
@@ -10,7 +10,7 @@
  *
  * @private
  * @param {string} str - The string to convert.
- * @return {(string|number|boolean)} The converted value.
+ * @returns {(string|number|boolean)} The converted value.
  */
 function castString(str) {
     let number;
@@ -66,8 +66,8 @@ function castString(str) {
  * converted to the appropriate types. The original object or array is not modified.
  *
  * @private
- * @param {(string|Object|Array)} item - The item whose type or types will be converted.
- * @return {*?} The converted value.
+ * @param {(string|object|Array)} item - The item whose type or types will be converted.
+ * @returns {*?} The converted value.
  */
 const cast = module.exports = item => {
     let result;

--- a/packages/jsdoc-task-runner/lib/validators.js
+++ b/packages/jsdoc-task-runner/lib/validators.js
@@ -1,6 +1,12 @@
 const ow = require('ow');
 const Task = require('./task');
 
+/**
+ * FIXME
+ *
+ * @param {object} t - A task object.
+ * @returns {object} FIXME
+ */
 function checkTask(t) {
     return {
         validator: t instanceof Task,

--- a/packages/jsdoc/cli.js
+++ b/packages/jsdoc/cli.js
@@ -86,11 +86,17 @@ module.exports = (() => {
 
     // TODO: docs
     cli.configureLogger = () => {
-        function recoverableError() {
+        /**
+         *
+         */
+function recoverableError() {
             props.shouldExitWithError = true;
         }
 
-        function fatalError() {
+        /**
+         *
+         */
+function fatalError() {
             cli.exit(1);
         }
 
@@ -214,6 +220,14 @@ module.exports = (() => {
         }
     };
 
+    /**
+     * Reads the `package.json` at `filepath`, ignoring comments.
+     * (This deviates from the strict definition of JSON, which forbids comments.)
+     *
+     * @param {string} filepath - The path to the JSON file.
+     * @returns {(string|null)} The contents of the the parsed file (or `null`, if the file
+     * could not be read).
+     */
     function readPackageJson(filepath) {
         const fs = require('jsdoc/fs');
 
@@ -227,6 +241,11 @@ module.exports = (() => {
         }
     }
 
+    /**
+     * @todo Add a description!
+     *
+     * @returns {Array} The list of source files.
+     */
     function buildSourceList() {
         const Readme = require('jsdoc/readme');
 
@@ -291,6 +310,12 @@ module.exports = (() => {
         return cli;
     };
 
+    /**
+     * Resolves `paths` for JSDoc plugins.
+     *
+     * @param {Array.<string>} paths - A list of paths to plugins.
+     * @returns {Array.<string>} The resolved paths.
+     */
     function resolvePluginPaths(paths) {
         const path = require('jsdoc/path');
 

--- a/packages/jsdoc/lib/jsdoc/augment.js
+++ b/packages/jsdoc/lib/jsdoc/augment.js
@@ -1,5 +1,6 @@
 /**
  * Provides methods for augmenting the parse results based on their content.
+ *
  * @module jsdoc/augment
  */
 
@@ -11,6 +12,13 @@ const name = require('jsdoc/name');
 
 const hasOwnProp = Object.prototype.hasOwnProperty;
 
+/**
+ * Maps dependencies for `propertyName` in `index`.
+ *
+ * @param {object} index - FIXME
+ * @param {string} propertyName - The name of the property to look up in `index`.
+ * @returns {object} A map of dependencies.
+ */
 function mapDependencies(index, propertyName) {
     const dependencies = {};
     let doc;
@@ -67,12 +75,26 @@ class Sorter {
     }
 }
 
+/**
+ * Sort `dependencies` using a `Sorter`.
+ *
+ * @param {*} dependencies - FIXME
+ * @returns {Array} A sorted listed of `dependencies`.
+ */
 function sort(dependencies) {
     const sorter = new Sorter(dependencies);
 
     return sorter.sort();
 }
 
+/**
+ * FIXME
+ *
+ * @param {string} longname - FIXME
+ * @param {object.index}    - FIXME
+ * @param {*} scopes        - FIXME
+ * @returns {Array} A list of members.
+ */
 function getMembers(longname, {index}, scopes) {
     const memberof = index.memberof[longname] || [];
     const members = [];
@@ -86,18 +108,40 @@ function getMembers(longname, {index}, scopes) {
     return members;
 }
 
+/**
+ * Return the documented `longname` from `{index}`.
+ *
+ * @param {string} longname - FIXME
+ * @param {object} - FIXME
+ * @returns {string} The long name.
+ */
 function getDocumentedLongname(longname, {index}) {
     const doclets = index.documented[longname] || [];
 
     return doclets[doclets.length - 1];
 }
 
+/**
+ * Add a `propName:value` to each doclet in `doclets`.
+ *
+ * @param {Array.<module:jsdoc/doclet.Doclet>} doclets - A list of doclets to update.
+ * @param {string} propName - The property name to add to each doclet.
+ * @param {*} value         - The property value to add to each doclet.
+ * @returns {void}
+ */
 function addDocletProperty(doclets, propName, value) {
     for (let i = 0, l = doclets.length; i < l; i++) {
         doclets[i][propName] = value;
     }
 }
 
+/**
+ * FIXME
+ *
+ * @param {object} - FIXME
+ * @param {object} child - FIXME
+ * @returns {void}
+ */
 function reparentDoclet({longname}, child) {
     const parts = name.shorten(child.longname);
 
@@ -106,10 +150,22 @@ function reparentDoclet({longname}, child) {
     child.longname = name.combine(parts);
 }
 
+/**
+ * Return whether a parent is a class.
+ *
+ * @param {object} - FIXME
+ * @returns {boolean} Whether `kind` is a class.
+ */
 function parentIsClass({kind}) {
     return kind === 'class';
 }
 
+/**
+ * Update `doclet` to instance type.
+ *
+ * @param {module:jsdoc/doclet.Doclet} doclet - FIXME
+ * @returns {void}
+ */
 function staticToInstance(doclet) {
     const parts = name.shorten(doclet.longname);
 
@@ -121,20 +177,27 @@ function staticToInstance(doclet) {
 /**
  * Update the list of doclets to be added to another symbol.
  *
- * We add only one doclet per longname. For example: If `ClassA` inherits from two classes that both
+ * Only one doclet is added per longname. For example: If `ClassA` inherits from two classes that both
  * use the same method name, `ClassA` gets docs for one method rather than two.
  *
- * Also, the last symbol wins for any given longname. For example: If you write `@extends Class1
- * @extends Class2`, and both classes have an instance method called `myMethod`, you get the docs
- * from `Class2#myMethod`.
+ * Also, the last symbol wins for any given longname. For example, if you write the following:
+ *
+ * <pre><code>
+ *
+ * @augments Class1
+ * @augments Class2
+ * </code></pre>
+ *
+ * ...and both classes have an instance method called `myMethod()`, you get the docs from
+ * `Class2#myMethod`.
  *
  * @private
  * @param {module:jsdoc/doclet.Doclet} doclet - The doclet to be added.
  * @param {Array.<module:jsdoc/doclet.Doclet>} additions - An array of doclets that will be added to
  * another symbol.
- * @param {Object.<string, number>} indexes - A dictionary of indexes into the `additions` array.
+ * @param {object.<string, number>} indexes - A dictionary of indexes into the `additions` array.
  * Each key is a longname, and each value is the index of the longname's doclet.
- * @return {void}
+ * @returns {void}
  */
 function updateAddedDoclets(doclet, additions, indexes) {
     if (typeof indexes[doclet.longname] !== 'undefined') {
@@ -153,9 +216,9 @@ function updateAddedDoclets(doclet, additions, indexes) {
  *
  * @private
  * @param {module:jsdoc/doclet.Doclet} doclet - The doclet to be added to the index.
- * @param {Object.<string, Array.<module:jsdoc/doclet.Doclet>>} documented - The index of doclets
+ * @param {object.<string, Array.<module:jsdoc/doclet.Doclet>>} documented - The index of doclets
  * whose `undocumented` property is not `true`.
- * @return {void}
+ * @returns {void}
  */
 function updateDocumentedDoclets(doclet, documented) {
     if ( !hasOwnProp.call(documented, doclet.longname) ) {
@@ -170,9 +233,9 @@ function updateDocumentedDoclets(doclet, documented) {
  *
  * @private
  * @param {module:jsdoc/doclet.Doclet} doclet - The doclet to be added to the index.
- * @param {Object.<string, Array.<module:jsdoc/doclet.Doclet>>} memberof - The index of doclets
+ * @param {object.<string, Array.<module:jsdoc/doclet.Doclet>>} memberof - The index of doclets
  * with a `memberof` value.
- * @return {void}
+ * @returns {void}
  */
 function updateMemberofDoclets(doclet, memberof) {
     if (doclet.memberof) {
@@ -184,6 +247,12 @@ function updateMemberofDoclets(doclet, memberof) {
     }
 }
 
+/**
+ * Returns whether any items in `doclets` inherits or overrides.
+ *
+ * @param {Array.<module:jsdoc/doclet.Doclet>} doclets - A list of doclets to search.
+ * @returns {boolean} True if any doclet inherits or overrides.
+ */
 function explicitlyInherits(doclets) {
     let doclet;
     let inherits = false;
@@ -199,6 +268,13 @@ function explicitlyInherits(doclets) {
     return inherits;
 }
 
+/**
+ * Updates the `memberof` value for `longname`.
+ *
+ * @param {string} longname - The member’s longname.
+ * @param {*} newMemberof   - FIXME
+ * @returns {*} FIXME
+ */
 function changeMemberof(longname, newMemberof) {
     const atoms = name.shorten(longname);
 
@@ -207,7 +283,16 @@ function changeMemberof(longname, newMemberof) {
     return name.combine(atoms);
 }
 
-// TODO: try to reduce overlap with similar methods
+
+/**
+ * FIXME
+ *
+ * @todo - try to reduce overlap with similar methods
+ * @param {Array.<module:jsdoc/doclet.Doclet>} doclets - A list of doclets.
+ * @param {*} docs - FIXME
+ * @param {object} - FIXME
+ * @returns {Array} A list of inherited additions.
+ */
 function getInheritedAdditions(doclets, docs, {documented, memberof}) {
     let additionIndexes;
     const additions = [];
@@ -317,6 +402,13 @@ function getInheritedAdditions(doclets, docs, {documented, memberof}) {
     return additions;
 }
 
+/**
+ * FIXME
+ *
+ * @param {*} mixedDoclet   - FIXME
+ * @param {*} mixedLongname - FIXME
+ * @returns {void}
+ */
 function updateMixes(mixedDoclet, mixedLongname) {
     let idx;
     let mixedName;
@@ -344,7 +436,15 @@ function updateMixes(mixedDoclet, mixedLongname) {
     }
 }
 
-// TODO: try to reduce overlap with similar methods
+/**
+ * FIXME
+ *
+ * @todo - try to reduce overlap with similar methods
+ * @param {Array.<module:jsdoc/doclet.Doclet>} mixinDoclets - FIXME
+ * @param {Array.<module:jsdoc/doclet.Doclet>} allDoclets - FIXME
+ * @param {object} - FIXME
+ * @returns {Array} A list of mixed in additions.
+ */
 function getMixedInAdditions(mixinDoclets, allDoclets, {documented, memberof}) {
     let additionIndexes;
     const additions = [];
@@ -397,6 +497,13 @@ function getMixedInAdditions(mixinDoclets, allDoclets, {documented, memberof}) {
     return additions;
 }
 
+/**
+ * FIXME
+ *
+ * @param {Array.<module:jsdoc/doclet.Doclet>} implDoclets - FIXME
+ * @param {*} implementedLongname - FIXME
+ * @returns {void}
+ */
 function updateImplements(implDoclets, implementedLongname) {
     if ( !Array.isArray(implDoclets) ) {
         implDoclets = [implDoclets];
@@ -413,7 +520,15 @@ function updateImplements(implDoclets, implementedLongname) {
     });
 }
 
-// TODO: try to reduce overlap with similar methods
+/**
+ * FIXME
+ *
+ * @todo - try to reduce overlap with similar methods
+ * @param {Array.<module:jsdoc/doclet.Doclet>} implDoclets - FIXME
+ * @param {Array.<module:jsdoc/doclet.Doclet>} allDoclets - FIXME
+ * @param {object} - FIXME
+ * @returns {Array} A list of mixed in additions.
+ */
 function getImplementedAdditions(implDoclets, allDoclets, {documented, memberof}) {
     let additionIndexes;
     const additions = [];
@@ -515,6 +630,14 @@ function getImplementedAdditions(implDoclets, allDoclets, {documented, memberof}
     return additions;
 }
 
+/**
+ * FIXME
+ *
+ * @param {Array.<module:jsdoc/doclet.Doclet>} doclets - FIXME
+ * @param {string} propertyName - FIXME
+ * @param {*} docletFinder      - FIXME
+ * @returns {void}
+ */
 function augment(doclets, propertyName, docletFinder) {
     const index = doclets.index.longname;
     const dependencies = sort( mapDependencies(index, propertyName) );
@@ -541,8 +664,8 @@ function augment(doclets, propertyName, docletFinder) {
  * calling this method creates a new doclet for `ClassB#myMethod`.
  *
  * @param {!Array.<module:jsdoc/doclet.Doclet>} doclets - The doclets generated by JSDoc.
- * @param {!Object} doclets.index - The doclet index.
- * @return {void}
+ * @param {!object} doclets.index - The doclet index.
+ * @returns {void}
  */
 exports.addInherited = doclets => {
     augment(doclets, 'augments', getInheritedAdditions);
@@ -560,8 +683,8 @@ exports.addInherited = doclets => {
  * creates a new doclet for the instance method `ClassA#myMethod`.
  *
  * @param {!Array.<module:jsdoc/doclet.Doclet>} doclets - The doclets generated by JSDoc.
- * @param {!Object} doclets.index - The doclet index.
- * @return {void}
+ * @param {!object} doclets.index - The doclet index.
+ * @returns {void}
  */
 exports.addMixedIn = doclets => {
     augment(doclets, 'mixes', getMixedInAdditions);
@@ -580,9 +703,9 @@ exports.addMixedIn = doclets => {
  * If `ClassA#myMethod` used the `@override` or `@inheritdoc` tag, calling this method would also
  * generate a new doclet that reflects the interface's documentation for `InterfaceA#myMethod`.
  *
- * @param {!Array.<module:jsdoc/doclet.Doclet>} docs - The doclets generated by JSDoc.
- * @param {!Object} doclets.index - The doclet index.
- * @return {void}
+ * @param {!Array.<module:jsdoc/doclet.Doclet>} doclets - The doclets generated by JSDoc.
+ * @param {!object} doclets.index - The doclet index.
+ * @returns {void}
  */
 exports.addImplemented = doclets => {
     augment(doclets, 'implements', getImplementedAdditions);
@@ -597,7 +720,8 @@ exports.addImplemented = doclets => {
  *
  * Calling this method is equivalent to calling all other methods exported by this module.
  *
- * @return {void}
+ * @param {!Array.<module:jsdoc/doclet.Doclet>} doclets - The doclets to augment.
+ * @returns {void}
  */
 exports.augmentAll = doclets => {
     exports.addMixedIn(doclets);

--- a/packages/jsdoc/lib/jsdoc/borrow.js
+++ b/packages/jsdoc/lib/jsdoc/borrow.js
@@ -1,10 +1,18 @@
 /**
  * A collection of functions relating to resolving @borrows tags in JSDoc symbols.
+ *
  * @module jsdoc/borrow
  */
 const _ = require('lodash');
 const { SCOPE } = require('jsdoc/name');
 
+/**
+ * FIXME
+ *
+ * @param {object} - FIXME
+ * @param {Array.<module:jsdoc/doclet.Doclet>} doclets - FIXME
+ * @returns {void}
+ */
 function cloneBorrowedDoclets({borrowed, longname}, doclets) {
     borrowed.forEach(({from, as}) => {
         const borrowedDoclets = doclets.index.longname[from];
@@ -37,10 +45,13 @@ function cloneBorrowedDoclets({borrowed, longname}, doclets) {
 }
 
 /**
-    Take a copy of the docs for borrowed symbols and attach them to the
-    docs for the borrowing symbol. This process changes the symbols involved,
-    moving docs from the "borrowed" array and into the general docs, then
-    deleting the "borrowed" array.
+ *  Take a copy of the docs for borrowed symbols and attach them to the
+ *  docs for the borrowing symbol. This process changes the symbols involved,
+ *  moving docs from the "borrowed" array and into the general docs, then
+ *  deleting the "borrowed" array.
+ *
+ * @param {Array.<module:jsdoc/doclet.Doclet>} doclets - FIXME
+ * @returns {void}
  */
 exports.resolveBorrows = doclets => {
     for (let doclet of doclets.index.borrowed) {

--- a/packages/jsdoc/lib/jsdoc/doclet.js
+++ b/packages/jsdoc/lib/jsdoc/doclet.js
@@ -1,5 +1,5 @@
 /**
- * @module jsdoc/doclet
+ * @module module:jsdoc/doclet
  */
 const _ = require('lodash');
 let dictionary = require('jsdoc/tag/dictionary');
@@ -9,6 +9,14 @@ const path = require('jsdoc/path');
 const { Syntax } = require('jsdoc/src/syntax');
 const { Tag } = require('jsdoc/tag');
 
+/**
+ * Updates `doclet` with the key-value pair of `title`:`value`.
+ *
+ * @param {module:jsdoc/doclet.Doclet} doclet - The doclet to update.
+ * @param {object} tag - The tag with the property name and value to add to `doclet`.
+ * @param {string} tag.title - The property name to add to `doclet`.
+ * @param {*}      tag.value - The property value to add to `doclet`.
+ */
 function applyTag(doclet, {title, value}) {
     if (title === 'name') {
         doclet.name = value;
@@ -23,6 +31,12 @@ function applyTag(doclet, {title, value}) {
     }
 }
 
+/**
+ * Returns fake metadata for `node`.
+ *
+ * @param {object} node - FIXME
+ * @returns {object} FIXME
+ */
 function fakeMeta(node) {
     return {
         type: node ? node.type : null,
@@ -31,7 +45,14 @@ function fakeMeta(node) {
 }
 
 // use the meta info about the source code to guess what the doclet kind should be
-// TODO: set this elsewhere (maybe jsdoc/src/astnode.getInfo)
+/**
+ * Gets a string representing the “kind” value of `code`.
+ *
+ * @todo - set this elsewhere (maybe jsdoc/src/astnode.getInfo)
+ *
+ * @param {*} code - FIXME
+ * @returns {string} The `kind` value of `code`.
+ */
 function codeToKind(code) {
     let kind = 'member';
     const node = code.node;
@@ -69,6 +90,12 @@ function codeToKind(code) {
     return kind;
 }
 
+/**
+ * FIXME
+ *
+ * @param {string} docletSrc - The raw source code of the JSDoc comment.
+ * @returns {string} The unwrapped source code of `docletSrc`.
+ */
 function unwrap(docletSrc) {
     if (!docletSrc) { return ''; }
 
@@ -91,7 +118,10 @@ function unwrap(docletSrc) {
 
 /**
  * Convert the raw source of the doclet comment into an array of pseudo-Tag objects.
+ *
  * @private
+ * @param {string} docletSrc - The raw source code of the JSDoc comment.
+ * @returns {Array.<object.<string, string>>} An array of pseudo-Tag objects.
  */
 function toTags(docletSrc) {
     let parsedTag;
@@ -127,6 +157,14 @@ function toTags(docletSrc) {
     return tagData;
 }
 
+/**
+ * FIXME
+ *
+ * @param {string} docletSrc - The raw source code of the JSDoc comment.
+ * @param {object} fixMyName - FIXME
+ * @param {object} fixMyName.code - FIXME
+ * @returns {string} FIXME
+ */
 function fixDescription(docletSrc, {code}) {
     let isClass;
 
@@ -155,6 +193,12 @@ exports._replaceDictionary = function _replaceDictionary(dict) {
     require('jsdoc/util/templateHelper')._replaceDictionary(dict);
 };
 
+/**
+ * FIXME
+ *
+ * @param {string} longname - FIXME
+ * @returns {string} FIXME
+ */
 function removeGlobal(longname) {
     const globalRegexp = new RegExp(`^${name.LONGNAMES.GLOBAL}\\.?`);
 
@@ -165,8 +209,8 @@ function removeGlobal(longname) {
  * Get the full path to the source file that is associated with a doclet.
  *
  * @private
- * @param {module:jsdoc/doclet.Doclet} The doclet to check for a filepath.
- * @return {string} The path to the doclet's source file, or an empty string if the path is not
+ * @param {module:jsdoc/doclet.Doclet} doclet - The doclet to check for a filepath.
+ * @returns {string} The path to the doclet's source file, or an empty string if the path is not
  * available.
  */
 function getFilepath(doclet) {
@@ -177,6 +221,14 @@ function getFilepath(doclet) {
     return path.join(doclet.meta.path || '', doclet.meta.filename);
 }
 
+/**
+ * Clone each property in `properties` from `source` to `target`.
+ *
+ * @param {object} source - The source to clone properties from.
+ * @param {object} target - The target to clone properties to.
+ * @param {*} properties - FIXME
+ * @returns {void}
+ */
 function clone(source, target, properties) {
     properties.forEach(property => {
         switch (typeof source[property]) {
@@ -196,8 +248,8 @@ function clone(source, target, properties) {
 }
 
 /**
- * Copy all but a list of excluded properties from one of two doclets onto a target doclet. Prefers
- * the primary doclet over the secondary doclet.
+ * Copy all but a list of excluded properties from one of two doclets onto a target doclet.
+ * Prefers the primary doclet over the secondary doclet.
  *
  * @private
  * @param {module:jsdoc/doclet.Doclet} primary - The primary doclet.
@@ -216,8 +268,8 @@ function copyMostProperties(primary, secondary, target, exclude) {
 
 /**
  * Copy specific properties from one of two doclets onto a target doclet, as long as the property
- * has a non-falsy value and a length greater than 0. Prefers the primary doclet over the secondary
- * doclet.
+ * has a non-falsy value and a `length` greater than `0`.
+ * Prefers the primary doclet over the secondary doclet.
  *
  * @private
  * @param {module:jsdoc/doclet.Doclet} primary - The primary doclet.
@@ -247,8 +299,8 @@ class Doclet {
     /**
      * Create a doclet.
      *
-     * @param {string} docletSrc - The raw source code of the jsdoc comment.
-     * @param {object=} meta - Properties describing the code related to this comment.
+     * @param {string} docletSrc - The raw source code of the JSDoc comment.
+     * @param {object} [meta={}] - Properties describing the code related to this comment.
      */
     constructor(docletSrc, meta = {}) {
         let newTags = [];
@@ -332,6 +384,7 @@ class Doclet {
     setMemberof(sid) {
         /**
          * The longname of the symbol that contains this one, if any.
+         *
          * @type {string}
          */
         this.memberof = removeGlobal(sid)
@@ -346,6 +399,7 @@ class Doclet {
     setLongname(longname) {
         /**
          * The fully resolved symbol name.
+         *
          * @type {string}
          */
         this.longname = removeGlobal(longname);
@@ -398,6 +452,7 @@ class Doclet {
         if (!this.borrowed) {
             /**
              * A list of symbols that are borrowed by this one, if any.
+             *
              * @type {Array.<string>}
              */
             this.borrowed = [];
@@ -408,7 +463,8 @@ class Doclet {
     mix(source) {
         /**
          * A list of symbols that are mixed into this one, if any.
-         * @type Array.<string>
+         *
+         * @type {Array.<string>}
          */
         this.mixes = this.mixes || [];
         this.mixes.push(source);
@@ -417,12 +473,13 @@ class Doclet {
     /**
      * Add a symbol to the doclet's `augments` array.
      *
-     * @param {string} base - The longname of the base symbol.
+     * @param {string} base - The `longname` of the base symbol.
      */
     augment(base) {
         /**
          * A list of symbols that are augmented by this one, if any.
-         * @type Array.<string>
+         *
+         * @type {Array.<string>}
          */
         this.augments = this.augments || [];
         this.augments.push(base);
@@ -431,13 +488,14 @@ class Doclet {
     /**
      * Set the `meta` property of this doclet.
      *
-     * @param {object} meta
+     * @param {object} meta - FIXME
      */
     setMeta(meta) {
         let pathname;
 
         /**
          * Information about the source code associated with this doclet.
+         *
          * @namespace
          */
         this.meta = this.meta || {};
@@ -445,7 +503,8 @@ class Doclet {
         if (meta.range) {
             /**
              * The positions of the first and last characters of the code associated with this doclet.
-             * @type Array.<number>
+             *
+             * @type {Array.<number>}
              */
             this.meta.range = meta.range.slice(0);
         }
@@ -453,17 +512,20 @@ class Doclet {
         if (meta.lineno) {
             /**
              * The name of the file containing the code associated with this doclet.
-             * @type string
+             *
+             * @type {string}
              */
             this.meta.filename = path.basename(meta.filename);
             /**
              * The line number of the code associated with this doclet.
-             * @type number
+             *
+             * @type {number}
              */
             this.meta.lineno = meta.lineno;
             /**
              * The column number of the code associated with this doclet.
-             * @type number
+             *
+             * @type {number}
              */
             this.meta.columnno = meta.columnno;
 
@@ -475,6 +537,7 @@ class Doclet {
 
         /**
          * Information about the code symbol.
+         *
          * @namespace
          */
         this.meta.code = this.meta.code || {};
@@ -483,6 +546,7 @@ class Doclet {
             if (meta.code.name) {
                 /**
                  * The name of the symbol in the source code.
+                 *
                  * @type {string}
                  */
                 this.meta.code.name = meta.code.name;
@@ -490,6 +554,7 @@ class Doclet {
             if (meta.code.type) {
                 /**
                  * The type of the symbol in the source code.
+                 *
                  * @type {string}
                  */
                 this.meta.code.type = meta.code.type;
@@ -506,6 +571,7 @@ class Doclet {
             if (typeof meta.code.value !== 'undefined') {
                 /**
                  * The value of the symbol in the source code.
+                 *
                  * @type {*}
                  */
                 this.meta.code.value = meta.code.value;

--- a/packages/jsdoc/lib/jsdoc/env.js
+++ b/packages/jsdoc/lib/jsdoc/env.js
@@ -8,7 +8,7 @@ module.exports = {
     /**
      * The times at which JSDoc started and finished.
      *
-     * @type {Object}
+     * @type {object}
      * @property {Date} start - The time at which JSDoc started running.
      * @property {Date} finish - The time at which JSDoc finished running.
      */
@@ -27,7 +27,7 @@ module.exports = {
     /**
      * The data parsed from JSDoc's configuration file.
      *
-     * @type Object<string, *>
+     * @type {object<string, *>}
      */
     conf: {},
 
@@ -50,9 +50,9 @@ module.exports = {
     /**
      * The command-line arguments, parsed into a key/value hash.
      *
-     * @type {Object}
+     * @type {object}
      * @example if (global.env.opts.help) { console.log('Helpful message.'); }
-    */
+     */
     opts: {},
 
     /**
@@ -66,7 +66,7 @@ module.exports = {
     /**
      * The JSDoc version number and revision date.
      *
-     * @type {Object<string, string>}
+     * @type {object<string, string>}
      * @property {string} number - The JSDoc version number.
      * @property {string} revision - The JSDoc revision number, expressed as a UTC date string.
      */

--- a/packages/jsdoc/lib/jsdoc/fs.js
+++ b/packages/jsdoc/lib/jsdoc/fs.js
@@ -1,5 +1,6 @@
 /**
  * Extended version of the standard `fs` module.
+ *
  * @module jsdoc/fs
  */
 const fs = require('fs');

--- a/packages/jsdoc/lib/jsdoc/name.js
+++ b/packages/jsdoc/lib/jsdoc/name.js
@@ -1,5 +1,6 @@
 /**
  * A collection of functions relating to JSDoc symbol name manipulation.
+ *
  * @module jsdoc/name
  */
 const _ = require('lodash');
@@ -21,7 +22,12 @@ const LONGNAMES = exports.LONGNAMES = {
     GLOBAL: '<global>'
 };
 
-// Module namespace prefix.
+/**
+ * Module namespace prefix.
+ *
+ * @constant
+ * @namespace
+ */
 const MODULE_NAMESPACE = 'module:';
 
 /**
@@ -63,12 +69,21 @@ const DESCRIPTION = '(?:(?:[ \\t]*\\-\\s*|\\s+)(\\S[\\s\\S]*))?$';
 const REGEXP_DESCRIPTION = new RegExp(DESCRIPTION);
 const REGEXP_NAME_DESCRIPTION = new RegExp(`^(\\[[^\\]]+\\]|\\S+)${DESCRIPTION}`);
 
+/**
+ * @param {string} name - FIXME
+ * @param {*} memberof - FIXME
+ * @returns {boolean} True if `name` is a longname defined in `memberof`.
+ */
 function nameIsLongname(name, memberof) {
     const regexp = new RegExp(`^${escape(memberof)}${SCOPE_PUNC_STRING}`);
 
     return regexp.test(name);
 }
 
+/**
+ * @param {string} name - A JSDoc symbol.
+ * @returns {string} FIXME
+ */
 function prototypeToPunc(name) {
     // don't mangle symbols named "prototype"
     if (name === 'prototype') {
@@ -78,10 +93,12 @@ function prototypeToPunc(name) {
     return name.replace(/(?:^|\.)prototype\.?/g, SCOPE.PUNC.INSTANCE);
 }
 
-// TODO: docs
 /**
+ *
+ * @todo - docs
+ *
  * @param {string} name - The symbol's longname.
- * @return {string} The symbol's basename.
+ * @returns {string} The symbol's basename.
  */
 exports.getBasename = name => {
     if (name !== undefined) {
@@ -91,10 +108,13 @@ exports.getBasename = name => {
     return undefined;
 };
 
-// TODO: deprecate exports.resolve in favor of a better name
+
 /**
- * Resolves the longname, memberof, variation and name values of the given doclet.
- * @param {module:jsdoc/doclet.Doclet} doclet
+ * Resolves the `longname`, `memberof`, `variation`, and `name` values of the given doclet.
+ *
+ * @todo Deprecate `exports.resolve` in favor of a better name.
+ *
+ * @param {module:jsdoc/doclet.Doclet} doclet - The doclet to resolve.
  */
 exports.resolve = doclet => {
     let about = {};
@@ -214,9 +234,10 @@ exports.resolve = doclet => {
 };
 
 /**
- * @param {string} longname The full longname of the symbol.
- * @param {string} ns The namespace to be applied.
- * @returns {string} The longname with the namespace applied.
+ * @function
+ * @param {string} longname - The full `longname` of the symbol.
+ * @param {string} ns - The `namespace` to be applied.
+ * @returns {string} The `longname` with the `namespace` applied.
  */
 exports.applyNamespace = (longname, ns) => {
     const nameParts = exports.shorten(longname);
@@ -231,15 +252,22 @@ exports.applyNamespace = (longname, ns) => {
     return longname;
 };
 
-// TODO: docs
+/**
+ * Strip namespace from `longname`.
+ *
+ * @function
+ * @param {string} longname - The longname to strip the namespace from.
+ * @returns {string} The namespace-stripped `longname`.
+ */
 exports.stripNamespace = longname => longname.replace(/^[a-zA-Z]+:/, '');
 
 /**
  * Check whether a parent longname is an ancestor of a child longname.
  *
+ * @function
  * @param {string} parent - The parent longname.
  * @param {string} child - The child longname.
- * @return {boolean} `true` if the parent is an ancestor of the child; otherwise, `false`.
+ * @returns {boolean} `true` if the parent is an ancestor of the child; otherwise, `false`.
  */
 exports.hasAncestor = (parent, child) => {
     let hasAncestor = false;
@@ -265,7 +293,14 @@ exports.hasAncestor = (parent, child) => {
     return hasAncestor;
 };
 
-// TODO: docs
+/**
+ * @todo - docs
+ *
+ * @param {string} longname - FIXME
+ * @param {Array} sliceChars - FIXME
+ * @param {string} [forcedMemberof] - FIXME
+ * @returns {object} FIXME
+ */
 function atomize(longname, sliceChars, forcedMemberof) {
     let i;
     let memberof = '';
@@ -343,17 +378,32 @@ function atomize(longname, sliceChars, forcedMemberof) {
     };
 }
 
-// TODO: deprecate exports.shorten in favor of a better name
 /**
- * Given a longname like "a.b#c(2)", slice it up into an object containing the memberof, the scope,
- * the name, and variation.
- * @param {string} longname
- * @param {string} forcedMemberof
+ * Given a longname like `"a.b#c(2)"`, slice it up into an object containing the `memberof`, the `scope`,
+ * the `name`, and `variation`.
+ *
+ * @todo Deprecate `exports.shorten` in favor of a better name.
+ *
+ * @function
+ * @param {string} longname - The longname to shorten.
+ * @param {string} forcedMemberof - FIXME
  * @returns {object} Representing the properties of the given name.
  */
 exports.shorten = (longname, forcedMemberof) => atomize(longname, SCOPE_PUNC, forcedMemberof);
 
-// TODO: docs
+
+/**
+ *
+ * @todo Docs
+ *
+ * @function
+ * @param {object} obj           - FIXME
+ * @param {string} obj.memberof  - FIXME
+ * @param {string} obj.scope     - FIXME
+ * @param {string} obj.name      - FIXME
+ * @param {string} obj.variation - FIXME
+ * @returns {string} The combined string value.
+ */
 exports.combine = ({memberof, scope, name, variation}) => [
     (memberof || ''),
     (scope || ''),
@@ -361,7 +411,13 @@ exports.combine = ({memberof, scope, name, variation}) => [
     (variation || '')
 ].join('');
 
-// TODO: docs
+/**
+ * @todo Docs
+ *
+ * @function
+ * @param {string} name - FIXME
+ * @returns {string} FIXME
+ */
 exports.stripVariation = name => {
     const parts = exports.shorten(name);
 
@@ -370,6 +426,11 @@ exports.stripVariation = name => {
     return exports.combine(parts);
 };
 
+/**
+ * @param {string} longname - FIXME - The longname to split.
+ * @param {object} options - FIXME
+ * @returns {object} FIXME
+ */
 function splitLongname(longname, options) {
     const chunks = [];
     let currentNameInfo;
@@ -403,13 +464,13 @@ function splitLongname(longname, options) {
  * Each level of the tree is an object with the following properties:
  *
  * + `longname {string}`: The longname.
- * + `memberof {string?}`: The memberof.
- * + `scope {string?}`: The longname's scope, represented as a punctuation mark (for example, `#`
+ * + `memberof {?string}`: The memberof.
+ * + `scope {?string}`: The longname's scope, represented as a punctuation mark (for example, `#`
  * for instance and `.` for static).
  * + `name {string}`: The short name.
- * + `doclet {Object?}`: The doclet associated with the longname, or `null` if the doclet was not
+ * + `doclet {?Object}`: The doclet associated with the longname, or `null` if the doclet was not
  * provided.
- * + `children {Object?}`: The children of the current longname. Not present if there are no
+ * + `children {?Object}`: The children of the current longname. Not present if there are no
  * children.
  *
  * For example, suppose you have the following array of doclet longnames:
@@ -472,11 +533,12 @@ function splitLongname(longname, options) {
  * }
  * ```
  *
- * @param {Array<string>} longnames - The longnames to convert into a tree.
- * @param {Object<string, module:jsdoc/doclet.Doclet>} doclets - The doclets to attach to a tree.
- * Each property should be the longname of a doclet, and each value should be the doclet for that
+ * @function
+ * @param {Array.<string>} longnames - The longnames to convert into a tree.
+ * @param {object.<string, module:jsdoc/doclet.Doclet>} doclets - The doclets to attach to a tree.
+ * Each property should be the `longname` of a doclet, and each value should be the doclet for that
  * longname.
- * @return {Object} A tree with information about each longname in the format shown above.
+ * @returns {object} A tree with information about each longname in the format shown above.
  */
 exports.longnamesToTree = (longnames, doclets) => {
     const splitOptions = { includeVariation: false };
@@ -521,9 +583,10 @@ exports.longnamesToTree = (longnames, doclets) => {
 /**
  * Split a string that starts with a name and ends with a description into its parts. Allows the
  * defaultvalue (if present) to contain brackets. If the name is found to have mismatched brackets,
- * null is returned.
- * @param {string} nameDesc
- * @returns {object} Hash with "name" and "description" properties.
+ * `null` is returned.
+ *
+ * @param {string} nameDesc - FIXME
+ * @returns {?object} Hash with `name` and `description` properties.
  */
 function splitNameMatchingBrackets(nameDesc) {
     const buffer = [];
@@ -565,11 +628,14 @@ function splitNameMatchingBrackets(nameDesc) {
 }
 
 
-// TODO: deprecate exports.splitName in favor of a better name
 /**
  * Split a string that starts with a name and ends with a description into its parts.
- * @param {string} nameDesc
- * @returns {object} Hash with "name" and "description" properties.
+ *
+ * @todo Deprecate `exports.splitName` in favor of a better name.
+ *
+ * @function
+ * @param {string} nameDesc - FIXME
+ * @returns {object} Hash with `name` and `description` properties.
  */
 exports.splitName = nameDesc => {
     // like: name, [name], name text, [name] text, name - text, or [name] - text

--- a/packages/jsdoc/lib/jsdoc/package.js
+++ b/packages/jsdoc/lib/jsdoc/package.js
@@ -8,7 +8,12 @@ const stripBom = require('strip-bom');
  * @see https://www.npmjs.org/doc/files/package.json.html
  */
 
-// Collect all of the license information from a `package.json` file.
+/**
+ * Collect all of the license information from a `package.json` file.
+ *
+ * @param {object} packageInfo - FIXME
+ * @returns {Array} A list of licenses.
+ */
 function getLicenses(packageInfo) {
     const licenses = packageInfo.licenses ? packageInfo.licenses.slice(0) : [];
 
@@ -22,7 +27,7 @@ function getLicenses(packageInfo) {
 /**
  * Information about where to report bugs in the package.
  *
- * @typedef {Object} module:jsdoc/package.Package~BugInfo
+ * @typedef {object} module:jsdoc/package.Package~BugInfo
  * @property {string} email - The email address for reporting bugs.
  * @property {string} url - The URL for reporting bugs.
  */
@@ -30,7 +35,7 @@ function getLicenses(packageInfo) {
 /**
  * Information about a package's software license.
  *
- * @typedef {Object} module:jsdoc/package.Package~LicenseInfo
+ * @typedef {object} module:jsdoc/package.Package~LicenseInfo
  * @property {string} type - An identifier for the type of license.
  * @property {string} url - The URL for the complete text of the license.
  */
@@ -38,7 +43,7 @@ function getLicenses(packageInfo) {
 /**
  * Information about a package author or contributor.
  *
- * @typedef {Object} module:jsdoc/package.Package~PersonInfo
+ * @typedef {object} module:jsdoc/package.Package~PersonInfo
  * @property {string} name - The person's full name.
  * @property {string} email - The person's email address.
  * @property {string} url - The URL of the person's website.
@@ -47,7 +52,7 @@ function getLicenses(packageInfo) {
 /**
  * Information about a package's version-control repository.
  *
- * @typedef {Object} module:jsdoc/package.Package~RepositoryInfo
+ * @typedef {object} module:jsdoc/package.Package~RepositoryInfo
  * @property {string} type - The type of version-control system that the repository uses (for
  * example, `git` or `svn`).
  * @property {string} url - The URL for the repository.
@@ -139,7 +144,7 @@ class Package {
             /**
              * The dependencies for this package.
              *
-             * @type {Object}
+             * @type {object}
              * @since 3.3.0
              */
             this.dependencies = packageInfo.dependencies;
@@ -158,7 +163,7 @@ class Package {
             /**
              * The development dependencies for this package.
              *
-             * @type {Object}
+             * @type {object}
              * @since 3.3.0
              */
             this.devDependencies = packageInfo.devDependencies;
@@ -171,7 +176,7 @@ class Package {
              * [semver](https://www.npmjs.org/doc/misc/semver.html)-compliant version number for the
              * engine.
              *
-             * @type {Object}
+             * @type {object}
              * @since 3.3.0
              */
             this.engines = packageInfo.engines;

--- a/packages/jsdoc/lib/jsdoc/path.js
+++ b/packages/jsdoc/lib/jsdoc/path.js
@@ -1,11 +1,19 @@
 /**
  * Extended version of the standard `path` module.
+ *
  * @module jsdoc/path
  */
 const env = require('jsdoc/env');
 const fs = require('fs');
 const path = require('path');
 
+/**
+ * @todo Add description.
+ *
+ * @param {string} previousPath - The previous path.
+ * @param {string} current - The current path.
+ * @returns {string} FIXME
+ */
 function prefixReducer(previousPath, current) {
     let currentPath = [];
 
@@ -47,7 +55,7 @@ function prefixReducer(previousPath, current) {
  * and an empty string is returned.
  *
  * @param {Array.<string>} paths - The paths to search for a common prefix.
- * @return {string} The common prefix, or an empty string if there is no common prefix.
+ * @returns {string} The common prefix, or an empty string if there is no common prefix.
  */
 exports.commonPrefix = (paths = []) => {
     let prefix = '';
@@ -99,13 +107,17 @@ exports.commonPrefix = (paths = []) => {
  * @param {string} filepath - The path to the requested resource. May be an absolute path; a path
  * relative to the JSDoc directory; or a path relative to the current working directory.
  * @param {string} [filename] - The filename of the requested resource.
- * @return {string} The fully qualified path to the requested resource. Includes the filename if one
+ * @returns {string} The fully qualified path to the requested resource. Includes the filename if one
  * was provided.
  */
 exports.getResourcePath = (filepath, filename) => {
     let result = null;
     const searchDirs = [env.pwd, path.dirname(env.opts.configure || ''), env.dirname];
 
+    /**
+     * @param {string} p - Path to check for existence.
+     * @returns {boolean} Whether the path exists.
+     */
     function exists(p) {
         try {
             fs.statSync(p);
@@ -117,6 +129,10 @@ exports.getResourcePath = (filepath, filename) => {
         }
     }
 
+    /**
+     * @param {string} p - Path to resolve.
+     * @returns {?string} The resolved path, or `null` if it could not be resolved.
+     */
     function resolve(p) {
         try {
             return require.resolve(p);
@@ -126,6 +142,10 @@ exports.getResourcePath = (filepath, filename) => {
         }
     }
 
+    /**
+     * @param {string} p - Path to check for existence.
+     * @returns {boolean} Whether `p` exists and can be resolved and `require()` -ed.
+     */
     function find(p) {
         // does the requested path exist?
         if ( exists(p) ) {

--- a/packages/jsdoc/lib/jsdoc/plugins.js
+++ b/packages/jsdoc/lib/jsdoc/plugins.js
@@ -1,15 +1,27 @@
 /**
  * Utility functions to support the JSDoc plugin framework.
+ *
  * @module jsdoc/plugins
  */
 const dictionary = require('jsdoc/tag/dictionary');
 
+/**
+ * @param {object} handlers - An hash of containing entries of  `event : handlers`.
+ * @param {module:jsdoc/src/parser.Parser} parser - Listens for the events
+ */
 function addHandlers(handlers, parser) {
     Object.keys(handlers).forEach(eventName => {
         parser.on(eventName, handlers[eventName]);
     });
 }
 
+/**
+ * @todo Add description
+ *
+ * @param {Array} plugins - A list of plugins.
+ * @param {module:jsdoc/src/parser.Parser} parser - The parser which will adopt plugins to use during future
+ * parsing.
+ */
 exports.installPlugins = (plugins, parser) => {
     let plugin;
 

--- a/packages/jsdoc/lib/jsdoc/readme.js
+++ b/packages/jsdoc/lib/jsdoc/readme.js
@@ -1,5 +1,6 @@
 /**
  * Make the contents of a README file available to include in the output.
+ *
  * @module jsdoc/readme
  */
 const env = require('jsdoc/env');

--- a/packages/jsdoc/lib/jsdoc/schema.js
+++ b/packages/jsdoc/lib/jsdoc/schema.js
@@ -1,5 +1,6 @@
 /**
  * Schema for validating JSDoc doclets.
+ *
  * @module jsdoc/schema
  * @see <https://trac.tools.ietf.org/html/draft-wright-json-schema-validation-01>
  */

--- a/packages/jsdoc/lib/jsdoc/src/astbuilder.js
+++ b/packages/jsdoc/lib/jsdoc/src/astbuilder.js
@@ -41,6 +41,11 @@ const parserOptions = exports.parserOptions = {
     sourceType: env.conf.source.type
 };
 
+/**
+ * @param {string} source - The source to parse (from `filename`).
+ * @param {string} filename - The filename of `source`.
+ * @returns {object} An abstract syntax tree (AST).
+ */
 function parse(source, filename) {
     let ast;
 
@@ -55,7 +60,7 @@ function parse(source, filename) {
     return ast;
 }
 
-// TODO: docs
+
 class AstBuilder {
     // TODO: docs
     /* eslint-disable no-empty-function */

--- a/packages/jsdoc/lib/jsdoc/src/astnode.js
+++ b/packages/jsdoc/lib/jsdoc/src/astnode.js
@@ -12,8 +12,8 @@ let uid = 100000000;
  * Check whether an AST node represents a function.
  *
  * @alias module:jsdoc/src/astnode.isFunction
- * @param {(Object|string)} node - The AST node to check, or the `type` property of a node.
- * @return {boolean} Set to `true` if the node is a function or `false` in all other cases.
+ * @param {(object|string)} node - The AST node to check, or the `type` property of a node.
+ * @returns {boolean} Whether or not `node` is a function.
  */
 const isFunction = exports.isFunction = node => {
     let type;
@@ -37,8 +37,8 @@ const isFunction = exports.isFunction = node => {
  * Check whether an AST node creates a new scope.
  *
  * @alias module:jsdoc/src/astnode.isScope
- * @param {Object} node - The AST node to check.
- * @return {Boolean} Set to `true` if the node creates a new scope, or `false` in all other cases.
+ * @param {object} node - The AST node to check.
+ * @returns {boolean} Whether or not `node` creates a new scope.
  */
 exports.isScope = node => // TODO: handle blocks with "let" declarations
     Boolean(node) && typeof node === 'object' && (node.type === Syntax.CatchClause ||
@@ -335,6 +335,9 @@ exports.isAssignment = node => Boolean(node) && typeof node === 'object' &&
 // TODO: docs
 /**
  * Retrieve information about the node, including its name and type.
+ *
+ * @param {object} node - The AST node to get info from.
+ * @returns {object} The info about `node`.
  */
 exports.getInfo = node => {
     const info = {};

--- a/packages/jsdoc/lib/jsdoc/src/filter.js
+++ b/packages/jsdoc/lib/jsdoc/src/filter.js
@@ -4,6 +4,10 @@
 const env = require('jsdoc/env');
 const path = require('jsdoc/path');
 
+/**
+ * @param {object} config - FIXME
+ * @returns {RegExp} A regular expression built from `config`.
+ */
 function makeRegExp(config) {
     let regExp = null;
 
@@ -19,10 +23,10 @@ function makeRegExp(config) {
  */
 class Filter {
     /**
-     * @param {Object} opts
+     * @param {object} opts - Options for the `Filter`.
      * @param {string[]} opts.exclude - Specific files to exclude.
-     * @param {(string|RegExp)} opts.includePattern
-     * @param {(string|RegExp)} opts.excludePattern
+     * @param {(string|RegExp)} opts.includePattern - Which files to include.
+     * @param {(string|RegExp)} opts.excludePattern - Which files to exclude.
      */
     constructor({exclude, includePattern, excludePattern}) {
         this.exclude = exclude && Array.isArray(exclude) ?

--- a/packages/jsdoc/lib/jsdoc/src/handlers.js
+++ b/packages/jsdoc/lib/jsdoc/src/handlers.js
@@ -16,6 +16,11 @@ class CurrentModule {
         this.originalName = doclet.meta.code.name || '';
     }
 }
+/**
+ * @param {module:jsdoc/doclet.Doclet} doclet - The doclet to filter by its `longname`.
+ * @param {string} doclet.longname - The `longname` to filter by.
+ * @returns {boolean} Whether the doclet passes the filter.
+ */
 function filterByLongname({longname}) {
     // you can't document prototypes
     if ( /#$/.test(longname) ) {
@@ -25,6 +30,11 @@ function filterByLongname({longname}) {
     return false;
 }
 
+/**
+ * @param {string} comment - FIXME
+ * @param {*} e - FIXME
+ * @returns {module:jsdoc/doclet.Doclet} The newly created doclet.
+ */
 function createDoclet(comment, e) {
     let doclet;
     let flatComment;
@@ -61,6 +71,9 @@ function createDoclet(comment, e) {
  * ignores the attached JSDoc comment and only looks at the code.
  *
  * @private
+ * @param {*} comment - A comment.
+ * @param {*} e - The `symbolFound` event.
+ * @returns {module:jsdoc/doclet.Doclet} e - A doclet created from `comment`.
  */
 function createSymbolDoclet(comment, e) {
     let doclet = createDoclet(comment, e);
@@ -74,12 +87,19 @@ function createSymbolDoclet(comment, e) {
     return doclet;
 }
 
+/**
+ * @param {module:jsdoc/doclet.Doclet} doclet - FIXME
+ */
 function setCurrentModule(doclet) {
     if (doclet.kind === 'module') {
         currentModule = new CurrentModule(doclet);
     }
 }
 
+/**
+ * @param {module:jsdoc/src/parser.Parser} parser - FIXME
+ * @param {module:jsdoc/doclet.Doclet} doclet - FIXME
+ */
 function setModuleScopeMemberOf(parser, doclet) {
     let parentDoclet;
     let skipMemberof;
@@ -132,6 +152,9 @@ function setModuleScopeMemberOf(parser, doclet) {
     }
 }
 
+/**
+ * @param {module:jsdoc/doclet.Doclet} doclet - FIXME
+ */
 function setDefaultScope(doclet) {
     // module doclets don't get a default scope
     if (!doclet.scope && doclet.kind !== 'module') {
@@ -139,6 +162,10 @@ function setDefaultScope(doclet) {
     }
 }
 
+/**
+ * @param {module:jsdoc/src/parser.Parser} parser - FIXME
+ * @param {module:jsdoc/doclet.Doclet} newDoclet - FIXME
+ */
 function addDoclet(parser, newDoclet) {
     let e;
 
@@ -153,6 +180,11 @@ function addDoclet(parser, newDoclet) {
     }
 }
 
+/**
+ * @param {module:jsdoc/src/parser.Parser} parser - FIXME
+ * @param {module:jsdoc/doclet.Doclet} doclet - FIXME
+ * @param {object} astNode - FIXME
+ */
 function processAlias(parser, doclet, astNode) {
     let memberofName;
 
@@ -170,7 +202,17 @@ function processAlias(parser, doclet, astNode) {
     doclet.postProcess();
 }
 
-// TODO: separate code that resolves `this` from code that resolves the module object
+/**
+ *
+ * @todo Separate code that resolves `this` from code that resolves the module object
+ *
+ * @param {module:jsdoc/src/parser.Parser} parser - FIXME
+ * @param {module:jsdoc/doclet.Doclet} doclet - FIXME
+ * @param {object} astNode - FIXME
+ * @param {string} nameStartsWith - FIXME
+ * @param {*} trailingPunc - FIXME
+ * @returns {object} (FIXME) Contains `memberof`, `scopePunc`.
+ */
 function findSymbolMemberof(parser, doclet, astNode, nameStartsWith, trailingPunc) {
     let memberof = '';
     let nameAndPunc;
@@ -223,6 +265,11 @@ function findSymbolMemberof(parser, doclet, astNode, nameStartsWith, trailingPun
     };
 }
 
+/**
+ * @param {module:jsdoc/src/parser.Parser} parser - FIXME
+ * @param {module:jsdoc/doclet.Doclet} doclet - FIXME
+ * @param {object} astNode - FIXME
+ */
 function addSymbolMemberof(parser, doclet, astNode) {
     let basename;
     let memberof;
@@ -275,6 +322,12 @@ function addSymbolMemberof(parser, doclet, astNode) {
     }
 }
 
+/**
+ * @param {module:jsdoc/src/parser.Parser} parser - FIXME
+ * @param {string} docletSrc - FIXME
+ * @param {*} e - FIXME
+ * @returns {boolean} FIXME
+ */
 function newSymbolDoclet(parser, docletSrc, e) {
     const newDoclet = createSymbolDoclet(docletSrc, e);
 
@@ -317,7 +370,8 @@ function newSymbolDoclet(parser, docletSrc, e) {
 
 /**
  * Attach these event handlers to a particular instance of a parser.
- * @param parser
+ *
+ * @param {module:jsdoc/src/parser.Parser} parser - FIXME
  */
 exports.attachTo = parser => {
     // Handle JSDoc "virtual comments" that include one of the following:

--- a/packages/jsdoc/lib/jsdoc/src/parser.js
+++ b/packages/jsdoc/lib/jsdoc/src/parser.js
@@ -12,12 +12,19 @@ const { Syntax } = require('jsdoc/src/syntax');
 
 const hasOwnProp = Object.prototype.hasOwnProperty;
 
-// TODO: docs
+/**
+ * @todo Docs
+ */
 const PARSERS = exports.PARSERS = {
     js: 'jsdoc/src/parser'
 };
 /* eslint-disable no-script-url */
-// Prefix for JavaScript strings that were provided in lieu of a filename.
+
+/**
+ * Prefix for JavaScript strings that were provided in lieu of a filename.
+ *
+ * @constant
+ */
 const SCHEMA = 'javascript:';
 /* eslint-enable no-script-url */
 
@@ -44,7 +51,13 @@ class DocletCache {
     }
 }
 
-// TODO: docs
+/**
+ * Create a parser from `type`.
+ *
+ * @function
+ * @param {*} type - FIXME
+ * @returns {module:jsdoc/src/parser.Parser} The newly created parser.
+ */
 exports.createParser = type => {
     let modulePath;
 
@@ -65,7 +78,11 @@ exports.createParser = type => {
     return new (require(modulePath).Parser)();
 };
 
-// TODO: docs
+/**
+ * @todo Docs
+ * @param {string} code - Code to pretreat.
+ * @returns {string} The pretreated code.
+ */
 function pretreat(code) {
     return code
         // comment out hashbang at the top of the file, like: #!/usr/bin/env node
@@ -77,19 +94,32 @@ function pretreat(code) {
         .replace(/\*\/\/\*\*+/g, '@also');
 }
 
-// TODO: docs
+/**
+ * @todo Docs
+ *
+ * @param {module:jsdoc/doclet.Doclet} doclet - The doclet to test for being in scope.
+ * @param {string} basename - FIXME
+ * @returns {boolean} Is `doclet` defined in scope?
+ */
 function definedInScope(doclet, basename) {
     return Boolean(doclet) && Boolean(doclet.meta) && Boolean(doclet.meta.vars) &&
         Boolean(basename) && hasOwnProp.call(doclet.meta.vars, basename);
 }
 
-// TODO: docs
 /**
+ * @todo Docs
+ *
  * @alias module:jsdoc/src/parser.Parser
- * @extends module:events.EventEmitter
+ * @augments module:events.EventEmitter
  */
 class Parser extends EventEmitter {
-    // TODO: docs
+    /**
+     * @todo Docs
+     *
+     * @param {object} builderInstance - FIXME
+     * @param {object} visitorInstance - FIXME
+     * @param {object} walkerInstance  - FIXME
+     */
     constructor(builderInstance, visitorInstance, walkerInstance) {
         super();
 
@@ -120,7 +150,7 @@ class Parser extends EventEmitter {
         });
     }
 
-    // TODO: docs
+    /** @todo Docs */
     clear() {
         this._resultBuffer = [];
         this._resultBuffer.index = {
@@ -136,11 +166,14 @@ class Parser extends EventEmitter {
         });
     }
 
-    // TODO: update docs
     /**
      * Parse the given source files for JSDoc comments.
-     * @param {Array.<string>} sourceFiles An array of filepaths to the JavaScript sources.
-     * @param {string} [encoding]
+     *
+     * @todo Update docs
+     *
+     * @param {Array.<string>} sourceFiles - An array of filepaths to the JavaScript sources.
+     * @param {string} [encoding] - FIXME
+     * @returns {*} The current Parser’s pseudo-private `_resultBuffer`.
      *
      * @fires module:jsdoc/src/parser.Parser.parseBegin
      * @fires module:jsdoc/src/parser.Parser.fileBegin
@@ -151,8 +184,8 @@ class Parser extends EventEmitter {
      * @fires module:jsdoc/src/parser.Parser.parseComplete
      *
      * @example <caption>Parse two source files.</caption>
-     * var myFiles = ['file1.js', 'file2.js'];
-     * var docs = jsdocParser.parse(myFiles);
+     *      let myFiles = ['file1.js', 'file2.js'];
+     *      let docs = jsdocParser.parse(myFiles);
      */
     parse(sourceFiles, encoding) {
         encoding = encoding || conf.encoding || 'utf8';
@@ -205,19 +238,27 @@ class Parser extends EventEmitter {
         return this._resultBuffer;
     }
 
-    // TODO: docs
+    /**
+     * @todo Docs
+     *
+     * @param {Array.<module:jsdoc/doclet.Doclet>} doclets - Doclets to fire with
+     * `processingComplete` event.
+     */
     fireProcessingComplete(doclets) {
         this.emit('processingComplete', { doclets: doclets });
     }
 
-    // TODO: docs
+    /**
+     * @returns {object} This parser’s `_resultBuffer`.
+     */
     results() {
         return this._resultBuffer;
     }
 
-    // TODO: update docs
     /**
-     * @param {module:jsdoc/doclet.Doclet} doclet The parse result to add to the result buffer.
+     * @todo Update docs
+     *
+     * @param {module:jsdoc/doclet.Doclet} doclet - The parse result to add to the result buffer.
      */
     addResult(doclet) {
         const index = this._resultBuffer.index;
@@ -252,17 +293,25 @@ class Parser extends EventEmitter {
         }
     }
 
-    // TODO: docs
+    /**
+     * @param {*} visitor - FIXME
+     */
     addAstNodeVisitor(visitor) {
         this._visitor.addAstNodeVisitor(visitor);
     }
 
-    // TODO: docs
+    /**
+     * @returns {*} FIXME
+     */
     getAstNodeVisitors() {
         return this._visitor.getAstNodeVisitors();
     }
 
-    /** @private */
+    /**
+     * @private
+     * @param {string} sourceCode - FIXME
+     * @param {string} sourceName - FIXME
+     */
     _parseSourceCode(sourceCode, sourceName) {
         let ast;
         let e = {
@@ -292,12 +341,21 @@ class Parser extends EventEmitter {
         this.emit('fileComplete', e);
     }
 
-    /** @private */
+    /**
+     * Recursively walk `ast` with `visitor` (and `sourceName`).
+     *
+     * @private
+     * @param {*} ast - FIXME
+     * @param {*} visitor - FIXME
+     * @param {*} sourceName - FIXME
+     */
     _walkAst(ast, visitor, sourceName) {
         this._walker.recurse(ast, visitor, sourceName);
     }
 
-    // TODO: docs
+    /**
+     * @param {*} e - FIXME
+     */
     addDocletRef(e) {
         let fakeDoclet;
         let node;
@@ -326,7 +384,10 @@ class Parser extends EventEmitter {
         }
     }
 
-    // TODO: docs
+    /**
+     * @param {*} id - FIXME
+     * @returns {module:jsdoc/doclet.Doclet} The doclet with `id`.
+     */
     _getDocletById(id) {
         return this._byNodeId.get(id);
     }
@@ -335,16 +396,18 @@ class Parser extends EventEmitter {
      * Retrieve the most recently seen doclet that has the given longname.
      *
      * @param {string} longname - The longname to search for.
-     * @return {module:jsdoc/doclet.Doclet?} The most recent doclet for the longname.
+     * @returns {?module:jsdoc/doclet.Doclet} The most recent doclet for the longname.
      */
     _getDocletByLongname(longname) {
         return this._byLongname.get(longname);
     }
 
-    // TODO: docs
     /**
      * Given a node, determine what the node is a member of.
-     * @param {node} node
+     *
+     * @todo Docs
+     *
+     * @param {object} node - FIXME
      * @returns {string} The long name of the node that this is a member of.
      */
     astnodeToMemberof(node) {
@@ -441,15 +504,20 @@ class Parser extends EventEmitter {
     /**
      * Get the doclet for the lowest-level class, if any, that is in the scope chain for a given node.
      *
-     * @param {Object} node - The node whose scope chain will be searched.
-     * @return {module:jsdoc/doclet.Doclet?} The doclet for the lowest-level class in the node's scope
-     * chain.
+     * @param {object} node - The node whose scope chain will be searched.
+     * @param {object} node.enclosingScope - The scope used during the search.
+     * @returns {?module:jsdoc/doclet.Doclet} The doclet for the lowest-level class in the
+     * node's scope chain.
      */
     _getParentClass({enclosingScope}) {
         let doclet;
         let nameAtoms;
         let scope = enclosingScope;
 
+        /**
+         * @param {object} d - FIXME
+         * @returns {boolean} Is `d` a class?
+         */
         function isClass(d) {
             return d && d.kind === 'class';
         }
@@ -482,11 +550,11 @@ class Parser extends EventEmitter {
         return (isClass(doclet) ? doclet : null);
     }
 
-    // TODO: docs
     /**
-     * Resolve what "this" refers to relative to a node.
-     * @param {node} node - The "this" node
-     * @returns {string} The longname of the enclosing node.
+     * Resolve what `this` refers to relative to a `node`.
+     *
+     * @param {object} node - The `this` node.
+     * @returns {string} The `longname` of the enclosing node.
      */
     resolveThis(node) {
         let doclet;
@@ -564,8 +632,8 @@ class Parser extends EventEmitter {
      * If the object is part of a chained assignment (for example, `var foo = exports.FOO = { x: 1 }`,
      * this method returns multiple doclets (in this case, the doclets for `foo` and `exports.FOO`).
      *
-     * @param {Object} node - An AST node representing an object property.
-     * @return {Array.<module:jsdoc/doclet.Doclet>} An array of doclets for the parent object or objects, or
+     * @param {object} node - An AST node representing an object property.
+     * @returns {Array.<module:jsdoc/doclet.Doclet>} An array of doclets for the parent object or objects, or
      * an empty array if no doclets are found.
      */
     resolvePropertyParents({parent}) {
@@ -595,11 +663,15 @@ class Parser extends EventEmitter {
         return doclets;
     }
 
-    // TODO: docs
     /**
-     * Resolve what function a var is limited to.
-     * @param {astnode} node
-     * @param {string} basename The leftmost name in the long name: in foo.bar.zip the basename is foo.
+     * Resolve which function a `var` is limited to.
+     *
+     * @todo Docs
+     *
+     * @param {object} node - FIXME
+     * @param {string} basename - The leftmost name in the long name. For example, in
+     * `foo.bar.zip`, the basename is `foo`.
+     * @returns {string} The resolved result.
      */
     resolveVar({enclosingScope, type}, basename) {
         let doclet;
@@ -627,7 +699,9 @@ class Parser extends EventEmitter {
         return result;
     }
 
-    // TODO: docs
+    /**
+     * @param {object} e - FIXME
+     */
     resolveEnum(e) {
         const doclets = this.resolvePropertyParents(e.code.node.parent);
 
@@ -652,14 +726,17 @@ class Parser extends EventEmitter {
 }
 exports.Parser = Parser;
 
-// TODO: document other events
+
 /**
  * Fired once for each JSDoc comment in the current source code.
+ *
+ * @todo Document other events.
+ *
  * @event jsdocCommentFound
  * @memberof module:jsdoc/src/parser.Parser
- * @type {Object}
- * @property {string} comment The text content of the JSDoc comment
- * @property {number} lineno The line number associated with the found comment.
- * @property {number} columnno The column number associated with the found comment.
- * @property {string} filename The file name associated with the found comment.
+ * @type {object}
+ * @property {string} comment   - The text content of the JSDoc comment
+ * @property {number} lineno    - The line number associated with the found comment.
+ * @property {number} columnno  - The column number associated with the found comment.
+ * @property {string} filename  - The file name associated with the found comment.
  */

--- a/packages/jsdoc/lib/jsdoc/src/scanner.js
+++ b/packages/jsdoc/lib/jsdoc/src/scanner.js
@@ -9,7 +9,7 @@ const logger = require('jsdoc/util/logger');
 const path = require('jsdoc/path');
 
 /**
- * @extends module:events.EventEmitter
+ * @augments module:events.EventEmitter
  */
 class Scanner extends EventEmitter {
     constructor() {
@@ -17,10 +17,17 @@ class Scanner extends EventEmitter {
     }
 
     /**
-     * Recursively searches the given searchPaths for js files.
-     * @param {Array.<string>} searchPaths
-     * @param {number} [depth]
+     * Recursively search `searchPaths` for files.
+     *
+     * @todo Default parameters should be last. (Fix `filter`.)
+     *
+     * @param {Array.<string>} [searchPaths=[]] - The paths to search.
+     * @param {number} [depth=1] - Depth to search.
+     * @param {module:jsdoc/src/filter.Filter} filter - The filter which determines which file(s) to return.
+     *
      * @fires sourceFileFound
+     *
+     * @returns {Array.<string>} Filepaths found during the search.
      */
     scan(searchPaths = [], depth = 1, filter) {
         let currentFile;

--- a/packages/jsdoc/lib/jsdoc/src/visitor.js
+++ b/packages/jsdoc/lib/jsdoc/src/visitor.js
@@ -1,7 +1,9 @@
 /**
  * @module jsdoc/src/visitor
+ *
+ * @todo Consider exporting more stuff so users can override it.
  */
-// TODO: consider exporting more stuff so users can override it
+
 const astNode = require('jsdoc/src/astnode');
 const combineDoclets = require('jsdoc/doclet').combine;
 const { getBasename, LONGNAMES } = require('jsdoc/name');
@@ -11,7 +13,8 @@ const { Syntax } = require('jsdoc/src/syntax');
  * Get the raw comment string for a block comment node.
  *
  * @private
- * @param {!Object} comment - A comment node with `type` and `value` properties.
+ * @param {!object} comment - A comment node with `type` and `value` properties.
+ * @returns {string} The raw comment.
  */
 function getRawComment({value}) {
     return `/*${value}*/`;
@@ -20,26 +23,37 @@ function getRawComment({value}) {
 /**
  * Check whether a comment node represents a block comment.
  *
- * @param {!Object} comment - A comment node with `type` and `value` properties.
- * @return {boolean} `true` if the comment is a block comment, `false` otherwise.
+ * @param {!object} comment - A comment node with `type` and `value` properties.
+ * @returns {boolean} Is the comment a block comment?
  */
 function isBlockComment({type}) {
     return type === 'CommentBlock';
 }
 
 /**
- * Verify that a block comment exists; that it is a JSDoc comment; and that its leading delimiter
- * does not contain three or more asterisks.
+ * Verify that a block comment...
+ *
+ * + exists;
+ * + is a JSDoc comment; and
+ * + that its leading delimiter does not contain three or more asterisks.
  *
  * @private
  * @memberof module:jsdoc/src/parser.Parser
+ * @param {string} commentSrc - The comment to validate.
+ * @returns {boolean} Is `commentSrc` valid JSDoc?
  */
 function isValidJsdoc(commentSrc) {
     return commentSrc && commentSrc.length > 4 && commentSrc.indexOf('/**') === 0 &&
         commentSrc.indexOf('/***') !== 0;
 }
 
-// TODO: docs
+
+/**
+ * @todo Docs
+ *
+ * @param {object} node - FIXME
+ * @returns {string} A JSDoc comment.
+ */
 function getLeadingJsdocComment(node) {
     let comment = null;
     let leadingComments = node.leadingComments;
@@ -61,7 +75,13 @@ function getLeadingJsdocComment(node) {
     return comment;
 }
 
-// TODO: docs
+
+/**
+ * @todo Docs
+ *
+ * @param {module:jsdoc/doclet.Doclet} scopeDoclet - FIXME
+ * @returns {*} FIXME
+ */
 function makeVarsFinisher(scopeDoclet) {
     return ({doclet, code}) => {
         // no need to evaluate all things related to scopeDoclet again, just use it
@@ -71,7 +91,13 @@ function makeVarsFinisher(scopeDoclet) {
     };
 }
 
-// Given an event, get the parent node's doclet.
+/**
+ * Given an event, get the parent node's doclet.
+ *
+ * @param {module:jsdoc/src/parser.Parser} parser - FIXME
+ * @param {object} fixMyName - FIXME
+ * @returns {?module:jsdoc/doclet.Doclet} A doclet (or `null`, if one could not be found).
+ */
 function getParentDocletFromEvent(parser, {doclet}) {
     if (doclet && doclet.meta && doclet.meta.code && doclet.meta.code.node &&
         doclet.meta.code.node.parent) {
@@ -88,7 +114,7 @@ function getParentDocletFromEvent(parser, {doclet}) {
  *
  * @private
  * @param {module:jsdoc/src/parser.Parser} parser - The JSDoc parser.
- * @return {function} A function that merges a parameter's inline documentation into the function's
+ * @returns {Function} A function that merges a parameter's inline documentation into the function's
  * doclet.
  */
 function makeInlineParamsFinisher(parser) {
@@ -145,12 +171,12 @@ function makeInlineParamsFinisher(parser) {
 }
 
 /**
- * Given an array of nodes that represent function parameters, find the node for the rest parameter,
- * if any.
+ * Given an array of nodes that represent function parameters, find the node for the
+ * rest parameter, if any.
  *
  * @private
- * @param {Array.<Object>} params - An array of nodes that represent function parameters.
- * @return {Object?} The node for the rest parameter.
+ * @param {Array.<object>} params - An array of nodes that represent function parameters.
+ * @returns {?object} The node for the rest parameter.
  */
 function findRestParam(params) {
     let restParam = null;
@@ -174,7 +200,7 @@ function findRestParam(params) {
  * is not documented, the function's doclet will remain unchanged.
  *
  * @private
- * @return {function} A function that updates the rest parameter's documentation to indicate that
+ * @returns {Function} A function that updates the rest parameter's documentation to indicate that
  * the parameter is repeatable.
  */
 function makeRestParamFinisher() {
@@ -209,8 +235,8 @@ function makeRestParamFinisher() {
  * parameters, if any.
  *
  * @private
- * @param {Array.<Object>} params - An array of nodes that represent function parameters.
- * @return {Array.<Object>} The nodes for the default parameters.
+ * @param {Array.<object>} params - An array of nodes that represent function parameters.
+ * @returns {Array.<object>} The nodes for the default parameters.
  */
 function findDefaultParams(params) {
     const defaultParams = [];
@@ -238,7 +264,7 @@ function findDefaultParams(params) {
  * documentation.
  *
  * @private
- * @return {function} A function that updates the function doclet to include the default values of
+ * @returns {Function} A function that updates the function doclet to include the default values of
  * parameters.
  */
 function makeDefaultParamFinisher() {
@@ -296,7 +322,7 @@ function makeDefaultParamFinisher() {
  *
  * @private
  * @param {module:jsdoc/src/parser.Parser} parser - The JSDoc parser.
- * @return {function} A function that merges the constructor's doclet into the class's doclet.
+ * @returns {Function} A function that merges the constructor's doclet into the class's doclet.
  */
 function makeConstructorFinisher(parser) {
     return e => {
@@ -335,7 +361,7 @@ function makeConstructorFinisher(parser) {
  * Create a function that will add an `async` property to the doclet for async functions.
  *
  * @private
- * @return {function} A function that adds an `async` property to the doclet of async functions.
+ * @returns {Function} A function that adds an `async` property to the doclet of async functions.
  */
 function makeAsyncFunctionFinisher() {
     return e => {
@@ -356,7 +382,7 @@ function makeAsyncFunctionFinisher() {
  * Create a function that will mark a doclet as private.
  *
  * @private
- * @return {function} A function that marks a doclet as private.
+ * @returns {Function} A function that marks a doclet as private.
  */
 function makePrivatePropertyFinisher() {
     return ({doclet}) => {
@@ -368,7 +394,7 @@ function makePrivatePropertyFinisher() {
  * Create a function that will mark a doclet as a generator function.
  *
  * @private
- * @return {function} A function that marks a doclet as a generator function.
+ * @returns {Function} A function that marks a doclet as a generator function.
  */
 function makeGeneratorFinisher() {
     return e => {
@@ -385,7 +411,9 @@ function makeGeneratorFinisher() {
     };
 }
 
-// TODO: docs
+/**
+ * @todo Docs
+ */
 class SymbolFound {
     // TODO: docs
     constructor(node, filename, extras = {}) {
@@ -407,7 +435,9 @@ class SymbolFound {
     }
 }
 
-// TODO: docs
+/**
+ * @todo Docs
+ */
 class JsdocCommentFound {
     // TODO: docs
     constructor({loc, range}, rawComment, filename) {
@@ -423,25 +453,44 @@ class JsdocCommentFound {
     }
 }
 
-// TODO: docs
+/**
+ * @todo Docs
+ *
+ * @param {object} node - The node to check for contained comments.
+ * @returns {boolean} Does the node contain comments?
+ */
 function hasComments(node) {
     return (node && node.leadingComments && node.leadingComments.length) ||
         (node && node.trailingComments && node.trailingComments.length) ||
         (node && node.innerComments && node.innerComments.length);
 }
 
-// TODO: docs
+/**
+ * Strip delimiters from `comment`.
+ *
+ * @param {string} comment - The comment to strip delimiters from.
+ * @returns {string} The `comment`, sans-delimiters.
+ */
 function removeCommentDelimiters(comment) {
     return comment.substring(2, comment.length - 2);
 }
 
-// TODO: docs
+/**
+ * @todo Docs
+ *
+ * @param {object} commentNode - FIXME
+ * @param {string} comment - FIXME
+ */
 function updateCommentNode(commentNode, comment) {
     commentNode.value = removeCommentDelimiters(comment);
 }
 
-// TODO: docs
-// TODO: note that it's essential to call this function before you try to resolve names!
+/**
+ * @todo Docs
+ * @todo Note that it's essential to call this function before you try to resolve names!
+ *
+ * @param {module:jsdoc/src/parser.Parser} parser - FIXME
+ */
 function trackVars(parser, {enclosingScope}, {code, finishers}) {
     let doclet;
     const enclosingScopeId = enclosingScope ? enclosingScope.nodeId : null;
@@ -460,7 +509,15 @@ function trackVars(parser, {enclosingScope}, {code, finishers}) {
     }
 }
 
-// TODO: docs
+
+/**
+ * @todo Docs
+ *
+ * @param {object} node - FIXME
+ * @param {module:jsdoc/src/parser.Parser} parser - FIXME
+ * @param {string} filename  - FIXME
+ * @returns {object} A `symbolFound` event.
+ */
 function makeSymbolFoundEvent(node, parser, filename) {
     let e;
     let basename;
@@ -700,7 +757,9 @@ function makeSymbolFoundEvent(node, parser, filename) {
     return e;
 }
 
-// TODO: docs
+/**
+ * @todo Docs
+ */
 class Visitor {
     // TODO: docs
     constructor() {
@@ -724,12 +783,16 @@ class Visitor {
         this._parser = parser;
     }
 
-    // TODO: docs
+    /**
+     * @param {object} visitor - Added to `this._nodeVisitors`.
+     */
     addAstNodeVisitor(visitor) {
         this._nodeVisitors.push(visitor);
     }
 
-    // TODO: docs
+    /**
+     * @param {object} visitor - Removed from `this._nodeVisitors`.
+     */
     removeAstNodeVisitor(visitor) {
         const idx = this._nodeVisitors.indexOf(visitor);
 
@@ -738,12 +801,21 @@ class Visitor {
         }
     }
 
-    // TODO: docs
+    /**
+     * @returns {Array} The list of node visitors.
+     */
     getAstNodeVisitors() {
         return this._nodeVisitors;
     }
 
-    // TODO: docs; visitor signature is (node, parser, filename)
+    /**
+     * @todo Docs.
+     * @todo visitor signature is (node, parser, filename)
+     *
+     * @param {object} node - The node to visit.
+     * @param {string} filename - The filename being visited.
+     * @returns {boolean} Returns `true` when done.
+     */
     visit(node, filename) {
         for (let visitor of this._visitors) {
             visitor.call(this, node, this._parser, filename);
@@ -753,7 +825,14 @@ class Visitor {
     }
 
     /* eslint-disable class-methods-use-this */
-    // TODO: docs
+    /**
+     * @todo Docs
+     *
+     * @param {object} node - The node to visit for comments.
+     * @param {module:jsdoc/src/parser.Parser} parser - The parser to use.
+     * @param {string} filename - The filename being visited.
+     * @returns {boolean} Returns `true` when done.
+     */
     visitNodeComments(node, parser, filename) {
         let comments;
         let e;
@@ -763,6 +842,9 @@ class Visitor {
         let nextProgramNodeIndex;
         let rawComment;
 
+        /**
+         * @param {string} source - Source to add comments to.
+         */
         function addComments(source) {
             comments = comments.concat( source.slice(0) );
         }
@@ -822,7 +904,14 @@ class Visitor {
     }
     /* eslint-enable class-methods-use-this */
 
-    // TODO: docs
+    /**
+     * @todo Docs
+     *
+     * @param {object} node - The node to visit.
+     * @param {module:jsdoc/src/parser.Parser} parser - The parser to use.
+     * @param {string} filename - The filename being visited.
+     * @returns {boolean} Returns `true` when done.
+     */
     visitNode(node, parser, filename) {
         const e = makeSymbolFoundEvent(node, parser, filename);
 

--- a/packages/jsdoc/lib/jsdoc/src/walker.js
+++ b/packages/jsdoc/lib/jsdoc/src/walker.js
@@ -7,12 +7,24 @@ const astnode = require('jsdoc/src/astnode');
 const logger = require('jsdoc/util/logger');
 const { Syntax } = require('jsdoc/src/syntax');
 
-// TODO: docs
+
+/**
+ * @todo Docs
+ *
+ * @param {Array} scopes - A list of scopes.
+ * @returns {?object} The current scope (or `null`, if no scopes remain.)
+ */
 function getCurrentScope(scopes) {
     return scopes[scopes.length - 1] || null;
 }
 
-// TODO: docs
+/**
+ * @todo Docs
+ *
+ * @param {object} source - FIXME
+ * @param {object} target - FIXME
+ * @param {number} [count] - FIXME
+ */
 function moveLeadingComments(source, target, count) {
     if (source.leadingComments) {
         if (count === undefined) {
@@ -24,7 +36,13 @@ function moveLeadingComments(source, target, count) {
     }
 }
 
-// TODO: docs
+/**
+ * @todo Docs
+ *
+ * @param {object} source - FIXME
+ * @param {object} target - FIXME
+ * @param {number} [count] - FIXME
+ */
 function moveTrailingComments(source, target, count) {
     if (source.trailingComments) {
         if (count === undefined) {
@@ -39,10 +57,18 @@ function moveTrailingComments(source, target, count) {
 }
 
 /* eslint-disable no-empty-function, no-unused-vars */
+/**
+ * @param {object} node - FIXME
+ * @param {object} parent - FIXME
+ * @param {object} state - FIXME
+ * @param {Function} cb - A callback function.
+ */
 function leafNode(node, parent, state, cb) {}
 /* eslint-enable no-empty-function, no-unused-vars */
 
-// TODO: docs
+/**
+ * @todo Docs
+ */
 const walkers = exports.walkers = {};
 
 walkers[Syntax.ArrayExpression] = (node, parent, state, cb) => {
@@ -53,7 +79,13 @@ walkers[Syntax.ArrayExpression] = (node, parent, state, cb) => {
     }
 };
 
-// TODO: verify correctness
+/**
+ * @todo Verify correctness.
+ * @param {object} node - FIXME
+ * @param {object} parent -  FIXME
+ * @param {object} state -  FIXME
+ * @param {Function} cb - A callback function.
+ */
 walkers[Syntax.ArrayPattern] = (node, parent, state, cb) => {
     for (let element of node.elements) {
         // must be an identifier or an expression
@@ -149,10 +181,19 @@ walkers[Syntax.ClassExpression] = walkers[Syntax.ClassDeclaration];
 
 // walkers[Syntax.ClassProperty] is defined later
 
-// TODO: verify correctness
+/**
+ * @todo Verify correctness.
+ */
 walkers[Syntax.ComprehensionBlock] = walkers[Syntax.AssignmentExpression];
 
-// TODO: verify correctness
+/**
+ * @todo Verify correctness.
+ *
+ * @param {object} node - FIXME
+ * @param {object} parent -  FIXME
+ * @param {object} state -  FIXME
+ * @param {Function} cb - A callback function.
+ */
 walkers[Syntax.ComprehensionExpression] = (node, parent, state, cb) => {
     cb(node.body, node, state);
 
@@ -379,7 +420,14 @@ walkers[Syntax.LabeledStatement] = (node, parent, state, cb) => {
     cb(node.body, node, state);
 };
 
-// TODO: add scope info??
+/**
+ * @todo Add scope info??
+ *
+ * @param {object} node - FIXME
+ * @param {object} parent -  FIXME
+ * @param {object} state -  FIXME
+ * @param {Function} cb - A callback function.
+ */
 walkers[Syntax.LetStatement] = (node, parent, state, cb) => {
     for (let headItem of node.head) {
         cb(headItem.id, node, state);
@@ -645,11 +693,19 @@ class Walker {
             scopes: []
         };
 
+        /**
+         *
+         */
         function logUnknownNodeType({type}) {
             logger.debug('Found a node with unrecognized type %s. Ignoring the node and its ' +
                 'descendants.', type);
         }
 
+        /**
+         * @param {object} node - FIXME
+         * @param {object} parent -  FIXME
+         * @param {object} cbState - FIXME
+         */
         function cb(node, parent, cbState) {
             let currentScope;
 

--- a/packages/jsdoc/lib/jsdoc/tag.js
+++ b/packages/jsdoc/lib/jsdoc/tag.js
@@ -1,5 +1,6 @@
 /**
  * Functionality related to JSDoc tags.
+ *
  * @module jsdoc/tag
  * @requires module:jsdoc/env
  * @requires module:jsdoc/path
@@ -18,12 +19,24 @@ const tag = {
     type: require('jsdoc/tag/type')
 };
 
-// Check whether the text is the same as a symbol name with leading or trailing whitespace. If so,
-// the whitespace must be preserved, and the text cannot be trimmed.
+/**
+ * Check whether the text is the same as a symbol name with leading or trailing whitespace.
+ * If so, the whitespace must be preserved, and the text cannot be trimmed.
+ *
+ * @param {string} text - FIXME
+ * @param {object} meta - FIXME
+ * @returns {boolean} Can `text` be trimmed?
+ */
 function mustPreserveWhitespace(text, meta) {
     return meta && meta.code && meta.code.name === text && text.match(/(?:^\s+)|(?:\s+$)/);
 }
 
+/**
+ * @param {string} text - FIXME
+ * @param {object} opts - FIXME
+ * @param {object} meta - FIXME
+ * @returns {string} Trimmed `text`.
+ */
 function trim(text, opts, meta) {
     let indentMatcher;
     let match;
@@ -51,6 +64,11 @@ function trim(text, opts, meta) {
     return text;
 }
 
+/**
+ * @param {object} obj - FIXME
+ * @param {string} propName - FIXME
+ * @param {string} propValue - FIXME
+ */
 function addHiddenProperty(obj, propName, propValue) {
     Object.defineProperty(obj, propName, {
         value: propValue,
@@ -60,6 +78,12 @@ function addHiddenProperty(obj, propName, propValue) {
     });
 }
 
+/**
+ * @param {object} fixMyName - FIXME
+ * @param {object} fixMyNameToo - FIXME
+ * @param {object} meta - FIXME
+ * @returns {object} The parsed type.
+ */
 function parseType({text, originalTitle}, {canHaveName, canHaveType}, meta) {
     try {
         return tag.type.parse(text, canHaveName, canHaveType);
@@ -77,6 +101,11 @@ function parseType({text, originalTitle}, {canHaveName, canHaveType}, meta) {
     }
 }
 
+/**
+ * @param {object} tagInstance - FIXME
+ * @param {object} tagDef - FIXME
+ * @param {object} meta - FIXME
+ */
 function processTagText(tagInstance, tagDef, meta) {
     let tagType;
 
@@ -144,9 +173,9 @@ class Tag {
     /**
      * Constructs a new tag object. Calls the tag validator.
      *
-     * @param {string} tagTitle
-     * @param {string=} tagBody
-     * @param {object=} meta
+     * @param {string} tagTitle  - FIXME
+     * @param {string} [tagBody] - FIXME
+     * @param {object} [meta]    - FIXME
      */
     constructor(tagTitle, tagBody, meta) {
         let tagDef;

--- a/packages/jsdoc/lib/jsdoc/tag/dictionary.js
+++ b/packages/jsdoc/lib/jsdoc/tag/dictionary.js
@@ -23,7 +23,11 @@ class TagDefinition {
         });
     }
 
-    /** @private */
+    /**
+     * @private
+     * @param {object} synonymName - FIXME
+     * @returns {TagDefinition} The current instance.
+     */
     synonym(synonymName) {
         this._dictionary.defineSynonym(this.title, synonymName);
 

--- a/packages/jsdoc/lib/jsdoc/tag/dictionary/definitions.js
+++ b/packages/jsdoc/lib/jsdoc/tag/dictionary/definitions.js
@@ -1,5 +1,6 @@
 /**
  * Define tags that are known in JSDoc.
+ *
  * @module jsdoc/tag/dictionary/definitions
  */
 const _ = require('lodash');
@@ -20,7 +21,13 @@ const DEFINITIONS = {
 };
 const MODULE_NAMESPACE = 'module:';
 
-// Clone a tag definition, excluding synonyms.
+/**
+ * Clone a tag definition, excluding synonyms.
+ *
+ * @param {object} tagDef - FIXME
+ * @param {object} extras - FIXME
+ * @returns {object} A new tag definition (possibly extended with `extras`).
+ */
 function cloneTagDef(tagDef, extras) {
     const newTagDef = _.cloneDeep(tagDef);
 
@@ -29,6 +36,9 @@ function cloneTagDef(tagDef, extras) {
     return (extras ? _.extend(newTagDef, extras) : newTagDef);
 }
 
+/**
+ * @returns {Array.<string>} A list of source paths.
+ */
 function getSourcePaths() {
     const sourcePaths = env.sourceFiles.slice(0) || [];
 
@@ -45,6 +55,10 @@ function getSourcePaths() {
     return sourcePaths;
 }
 
+/**
+ * @param {string} filepath - The filepath to strip of its prefix.
+ * @returns {string} The stripped `filepath`.
+ */
 function filepathMinusPrefix(filepath) {
     const sourcePaths = getSourcePaths();
     const commonPrefix = path.commonPrefix(sourcePaths);
@@ -64,11 +78,19 @@ function filepathMinusPrefix(filepath) {
     return result;
 }
 
-/** @private */
+/**
+ * @private
+ * @param {module:jsdoc/doclet.Doclet} doclet - The doclet whose `kind` property to update.
+ * @param {object} fixMyName - FIXME
+ * @param {string} fixMyName.title - The new value for the `doclet.kind` property.
+ */
 function setDocletKindToTitle(doclet, {title}) {
     doclet.addTag( 'kind', title );
 }
 
+/**
+ * @param {module:jsdoc/doclet.Doclet} doclet - The doclet whose `scope` to update.
+ */
 function setDocletScopeToTitle(doclet, {title}) {
     try {
         doclet.setScope(title);
@@ -78,6 +100,9 @@ function setDocletScopeToTitle(doclet, {title}) {
     }
 }
 
+/**
+ * @param {module:jsdoc/doclet.Doclet} doclet - The doclet whose `name` to update.
+ */
 function setDocletNameToValue(doclet, {value, text}) {
     if (value && value.description) { // as in a long tag
         doclet.addTag('name', value.description);
@@ -87,18 +112,27 @@ function setDocletNameToValue(doclet, {value, text}) {
     }
 }
 
+/**
+ * @param {module:jsdoc/doclet.Doclet} doclet - The doclet to whose `name` to update.
+ */
 function setDocletNameToValueName(doclet, {value}) {
     if (value && value.name) {
         doclet.addTag('name', value.name);
     }
 }
 
+/**
+ * @param {module:jsdoc/doclet.Doclet} doclet - The doclet whose `description` to update.
+ */
 function setDocletDescriptionToValue(doclet, {value}) {
     if (value) {
         doclet.addTag('description', value);
     }
 }
 
+/**
+ * @param {module:jsdoc/doclet.Doclet} doclet - The doclet whose `type` to update.
+ */
 function setDocletTypeToValueType(doclet, {value}) {
     if (value && value.type) {
         // Add the type names and other type properties (such as `optional`).
@@ -111,6 +145,9 @@ function setDocletTypeToValueType(doclet, {value}) {
     }
 }
 
+/**
+ * @param {module:jsdoc/doclet.Doclet} doclet - The doclet whose `name` to update.
+ */
 function setNameToFile(doclet) {
     let docletName;
 
@@ -120,12 +157,19 @@ function setNameToFile(doclet) {
     }
 }
 
+/**
+ * @param {module:jsdoc/doclet.Doclet} doclet - The doclet whose `memberof` to update.
+ */
 function setDocletMemberof(doclet, {value}) {
     if (value && value !== '<global>') {
         doclet.setMemberof(value);
     }
 }
 
+/**
+ * @param {(module:jsdoc/doclet.Doclet|string)} docletOrNs - The doclet or namespace to update.
+ * @param {object} tag - FIXME
+ */
 function applyNamespace(docletOrNs, tag) {
     if (typeof docletOrNs === 'string') { // ns
         tag.value = name.applyNamespace(tag.value, docletOrNs);
@@ -139,6 +183,9 @@ function applyNamespace(docletOrNs, tag) {
     }
 }
 
+/**
+ * @param {module:jsdoc/doclet.Doclet} doclet - The doclet whose `name` to set.
+ */
 function setDocletNameToFilename(doclet) {
     let docletName = '';
 
@@ -150,12 +197,20 @@ function setDocletNameToFilename(doclet) {
     doclet.name = docletName;
 }
 
+/**
+ * @param {string} text - The tag type to parse.
+ * @returns {string} A type expression, or `text`.
+ */
 function parseTypeText(text) {
     const tagType = parseTagType(text, false, true);
 
     return tagType.typeExpression || text;
 }
 
+/**
+ * @param {module:jsdoc/doclet.Doclet} doclet - The doclet to parse.
+ * @returns {object} An object containing borrows (or an empty object, if none are found).
+ */
 function parseBorrows(doclet, {text}) {
     const m = /^([\s\S]+?)(?:\s+as\s+([\s\S]+))?$/.exec(text);
 
@@ -178,10 +233,19 @@ function parseBorrows(doclet, {text}) {
     }
 }
 
+/**
+ * @param {string} docletName - The doclet name to strip of its namespace.
+ * @returns {string} The namespace-free doclet name.
+ */
 function stripModuleNamespace(docletName) {
     return docletName.replace(/^module:/, '');
 }
 
+/**
+ * @param {string} string - The string to fetch the first word of.
+ * @returns {string} The first word of `string` (or an empty string, if the first word could
+ * not be found).
+ */
 function firstWordOf(string) {
     const m = /^(\S+)/.exec(string);
 
@@ -193,6 +257,11 @@ function firstWordOf(string) {
     }
 }
 
+/**
+ * @param {object} fixMyName - FIXME
+ * @param {object} fixMyName.value - FIXME
+ * @returns {string} The combined type names.
+ */
 function combineTypes({value}) {
     let combined;
 
@@ -848,6 +917,9 @@ baseTags = _.extend(baseTags, internalTags);
 // Tag dictionary for JSDoc.
 exports.jsdocTags = baseTags;
 
+/**
+ *
+ */
 function ignore() {
     // do nothing
 }
@@ -1016,6 +1088,10 @@ exports.closureTags = {
     }
 };
 
+/**
+ * @param {module:jsdoc/tag/dictionary} dictionary - FIXME
+ * @param {object} tagDefs - Tag definitions to add to `dictionary`.
+ */
 function addTagDefinitions(dictionary, tagDefs) {
     Object.keys(tagDefs).forEach(tagName => {
         let tagDef;
@@ -1040,8 +1116,8 @@ function addTagDefinitions(dictionary, tagDefs) {
  * If the `tagDefinitions` parameter is included, JSDoc adds only the tag definitions from the
  * `tagDefinitions` object. The configuration settings are ignored.
  *
- * @param {module:jsdoc/tag/dictionary} dictionary
- * @param {Object} [tagDefinitions] - A dictionary whose values define the rules for a JSDoc tag.
+ * @param {module:jsdoc/tag/dictionary} dictionary - FIXME
+ * @param {object} [tagDefinitions] - A dictionary whose values define the rules for a JSDoc tag.
  */
 exports.defineTags = (dictionary, tagDefinitions) => {
     let dictionaries;

--- a/packages/jsdoc/lib/jsdoc/tag/inline.js
+++ b/packages/jsdoc/lib/jsdoc/tag/inline.js
@@ -4,7 +4,7 @@
 /**
  * Information about an inline tag that was found within a string.
  *
- * @typedef {Object} InlineTagInfo
+ * @typedef {object} InlineTagInfo
  * @memberof module:jsdoc/tag/inline
  * @property {?string} completeTag - The entire inline tag, including its enclosing braces.
  * @property {?string} tag - The tag whose text was found.
@@ -14,7 +14,7 @@
 /**
  * Information about the results of replacing inline tags within a string.
  *
- * @typedef {Object} InlineTagResult
+ * @typedef {object} InlineTagResult
  * @memberof module:jsdoc/tag/inline
  * @property {Array.<module:jsdoc/tag/inline.InlineTagInfo>} tags - The inline tags that were found.
  * @property {string} newString - The updated text string after extracting or replacing the inline
@@ -28,7 +28,7 @@
  * @memberof module:jsdoc/tag/inline
  * @param {string} string - The complete string containing the inline tag.
  * @param {module:jsdoc/tag/inline.InlineTagInfo} tagInfo - Information about the inline tag.
- * @return {string} An updated version of the complete string.
+ * @returns {string} An updated version of the complete string.
  */
 
 /**
@@ -62,15 +62,22 @@ exports.isInlineTag = (string, tagName) => regExpFactory(tagName, '^', '$').test
  * Replace all instances of multiple inline tags with other text.
  *
  * @param {string} string - The string in which to replace the inline tags.
- * @param {Object} replacers - The functions that are used to replace text in the string. The keys
+ * @param {object} replacers - The functions that are used to replace text in the string. The keys
  * must contain tag names (for example, `link`), and the values must contain functions with the
  * type {@link module:jsdoc/tag/inline.InlineTagReplacer}.
- * @return {module:jsdoc/tag/inline.InlineTagResult} The updated string, as well as information
+ * @returns {module:jsdoc/tag/inline.InlineTagResult} The updated string, as well as information
  * about the inline tags that were found.
  */
 exports.replaceInlineTags = (string, replacers) => {
     const tagInfo = [];
 
+    /**
+     * @param {object} replacer - FIXME
+     * @param {object} tag - FIXME
+     * @param {object} match - FIXME
+     * @param {string} text - FIXME
+     * @returns {object} FIXME
+     */
     function replaceMatch(replacer, tag, match, text) {
         const matchedTag = {
             completeTag: match,
@@ -113,7 +120,7 @@ exports.replaceInlineTags = (string, replacers) => {
  * @param {string} tag - The name of the inline tag to replace.
  * @param {module:jsdoc/tag/inline.InlineTagReplacer} replacer - The function that is used to
  * replace text in the string.
- * @return {module:jsdoc/tag/inline.InlineTagResult} The updated string, as well as information
+ * @returns {module:jsdoc/tag/inline.InlineTagResult} The updated string, as well as information
  * about the inline tags that were found.
  */
 exports.replaceInlineTag = (string, tag, replacer) => {
@@ -129,7 +136,7 @@ exports.replaceInlineTag = (string, tag, replacer) => {
  *
  * @param {string} string - The string from which to extract text.
  * @param {?string} tag - The inline tag to extract.
- * @return {module:jsdoc/tag/inline.InlineTagResult} The updated string, as well as information
+ * @returns {module:jsdoc/tag/inline.InlineTagResult} The updated string, as well as information
  * about the inline tags that were found.
  */
 exports.extractInlineTag = (string, tag) => exports.replaceInlineTag(string, tag, (str, {completeTag}) => str.replace(completeTag, ''));

--- a/packages/jsdoc/lib/jsdoc/tag/type.js
+++ b/packages/jsdoc/lib/jsdoc/tag/type.js
@@ -15,7 +15,11 @@ const { splitName } = require('jsdoc/name');
  * @property {string} text - The updated tag text.
  */
 
-/** @private */
+/**
+ * @private
+ * @param {string} text - Text to unescape.
+ * @returns {string} The unescaped text.
+ */
 function unescapeBraces(text) {
     return text.replace(/\\\{/g, '{')
         .replace(/\\\}/g, '}');
@@ -26,7 +30,7 @@ function unescapeBraces(text) {
  *
  * @private
  * @param {string} string - The tag text.
- * @return {module:jsdoc/tag/type.TypeExpressionInfo} The type expression and updated tag text.
+ * @returns {module:jsdoc/tag/type.TypeExpressionInfo} The type expression and updated tag text.
  */
 function extractTypeExpression(string) {
     let completeExpression;
@@ -75,7 +79,13 @@ function extractTypeExpression(string) {
     };
 }
 
-/** @private */
+/**
+ * @private
+ * @param {string} tagValue - FIXME
+ * @param {boolean} canHaveName - FIXME
+ * @param {boolean} canHaveType - FIXME
+ * @returns {object} FIXME
+ */
 function getTagInfo(tagValue, canHaveName, canHaveType) {
     let name = '';
     let typeExpression = '';
@@ -115,7 +125,7 @@ function getTagInfo(tagValue, canHaveName, canHaveType) {
 /**
  * Information provided in a JSDoc tag.
  *
- * @typedef {Object} TagInfo
+ * @typedef {object} TagInfo
  * @memberof module:jsdoc/tag/type
  * @property {string} TagInfo.defaultvalue - The default value of the member.
  * @property {string} TagInfo.name - The name of the member (for example, `myParamName`).
@@ -132,14 +142,16 @@ function getTagInfo(tagValue, canHaveName, canHaveType) {
  * can vary (for example, in a function that accepts any number of parameters).
  */
 
-// TODO: move to module:jsdoc/name?
+
 /**
  * Extract JSDoc-style type information from the name specified in the tag info, including the
  * member name; whether the member is optional; and the default value of the member.
  *
+ * @todo Move to module:jsdoc/name?
+ *
  * @private
  * @param {module:jsdoc/tag/type.TagInfo} tagInfo - Information contained in the tag.
- * @return {module:jsdoc/tag/type.TagInfo} Updated information from the tag.
+ * @returns {module:jsdoc/tag/type.TagInfo} Updated information from the tag.
  */
 function parseName(tagInfo) {
     // like '[foo]' or '[ foo ]' or '[foo=bar]' or '[ foo=bar ]' or '[ foo = bar ]'
@@ -161,7 +173,12 @@ function parseName(tagInfo) {
     return tagInfo;
 }
 
-/** @private */
+/**
+ * @private
+ * @param {object} parsedType - FIXME
+ * @param {boolean} isOutermostType - FIXME
+ * @returns {Array} A list of types.
+ */
 function getTypeStrings(parsedType, isOutermostType) {
     let applications;
     let typeString;
@@ -224,7 +241,7 @@ function getTypeStrings(parsedType, isOutermostType) {
  *
  * @private
  * @param {module:jsdoc/tag/type.TagInfo} tagInfo - Information contained in the tag.
- * @return {module:jsdoc/tag/type.TagInfo} Updated information from the tag.
+ * @returns {module:jsdoc/tag/type.TagInfo} Updated information from the tag.
  */
 function parseTypeExpression(tagInfo) {
     let parsedType;
@@ -271,7 +288,7 @@ const typeParsers = [parseName, parseTypeExpression];
  * @param {boolean} canHaveName - Indicates whether the value can include a symbol name.
  * @param {boolean} canHaveType - Indicates whether the value can include a type expression that
  * describes the symbol.
- * @return {module:jsdoc/tag/type.TagInfo} Information obtained from the tag.
+ * @returns {module:jsdoc/tag/type.TagInfo} Information obtained from the tag.
  * @throws {Error} Thrown if a type expression cannot be parsed.
  */
 exports.parse = (tagValue, canHaveName, canHaveType) => {

--- a/packages/jsdoc/lib/jsdoc/tag/validator.js
+++ b/packages/jsdoc/lib/jsdoc/tag/validator.js
@@ -5,6 +5,11 @@
 const env = require('jsdoc/env');
 const logger = require('jsdoc/util/logger');
 
+/**
+ * @param {object} tagName - FIXME
+ * @param {object} desc - FIXME
+ * @returns {string} The constructed message.
+ */
 function buildMessage(tagName, {filename, lineno, comment}, desc) {
     let result = `The @${tagName} tag ${desc}. File: ${filename}, line: ${lineno}`;
 
@@ -17,6 +22,10 @@ function buildMessage(tagName, {filename, lineno, comment}, desc) {
 
 /**
  * Validate the given tag.
+ *
+ * @param {object} fixMyName - FIXME
+ * @param {object} tagDef - FIXME
+ * @param {object} meta - FIXME
  */
 exports.validate = ({title, text, value}, tagDef, meta) => {
     const allowUnknownTags = env.conf.tags.allowUnknownTags;

--- a/packages/jsdoc/lib/jsdoc/template.js
+++ b/packages/jsdoc/lib/jsdoc/template.js
@@ -1,5 +1,6 @@
 /**
  * Wrapper for Lodash's template utility to allow loading templates from files.
+ *
  * @module jsdoc/template
  */
 const _ = require('lodash');
@@ -27,8 +28,9 @@ class Template {
 
     /**
      * Loads template from given file.
+     *
      * @param {string} file - Template filename.
-     * @return {function} Returns template closure.
+     * @returns {Function} Returns template closure.
      */
     load(file) {
         return _.template(fs.readFileSync(file, 'utf8'), this.settings);
@@ -41,7 +43,7 @@ class Template {
      *
      * @param {string} file - Template filename.
      * @param {object} data - Template variables (doesn't have to be object, but passing variables dictionary is best way and most common use).
-     * @return {string} Rendered template.
+     * @returns {string} Rendered template.
      */
     partial(file, data) {
         file = path.resolve(this.path, file);
@@ -62,7 +64,7 @@ class Template {
      *
      * @param {string} file - Template filename.
      * @param {object} data - Template variables (doesn't have to be object, but passing variables dictionary is best way and most common use).
-     * @return {string} Rendered template.
+     * @returns {string} Rendered template.
      */
     render(file, data) {
         // main content

--- a/packages/jsdoc/lib/jsdoc/tutorial.js
+++ b/packages/jsdoc/lib/jsdoc/tutorial.js
@@ -39,7 +39,6 @@ class Tutorial {
      * @param {string} name - Tutorial name.
      * @param {string} content - Text content.
      * @param {number} type - Source formating.
-
      */
     constructor(name, content, type) {
         this.title = this.name = this.longname = name;
@@ -54,7 +53,7 @@ class Tutorial {
     /**
      * Moves children from current parent to different one.
      *
-     * @param {?Tutorial} parent - New parent. If null, the tutorial has no parent.
+     * @param {?Tutorial} parent - New parent. If `null`, the tutorial has no parent.
      */
     setParent(parent) {
         // removes node from old parent
@@ -91,7 +90,7 @@ class Tutorial {
     /**
      * Prepares source.
      *
-     * @return {string} HTML source.
+     * @returns {string} HTML source.
      */
     parse() {
         switch (this.type) {
@@ -114,7 +113,8 @@ exports.Tutorial = Tutorial;
 
 /**
  * Represents the root tutorial.
- * @extends {module:jsdoc/tutorial.Tutorial}
+ *
+ * @augments {module:jsdoc/tutorial.Tutorial}
  */
 class RootTutorial extends Tutorial {
     constructor() {
@@ -125,8 +125,9 @@ class RootTutorial extends Tutorial {
 
     /**
      * Retrieve a tutorial by name.
+     *
      * @param {string} name - Tutorial name.
-     * @return {module:jsdoc/tutorial.Tutorial} Tutorial instance.
+     * @returns {module:jsdoc/tutorial.Tutorial} Tutorial instance.
      */
     getByName(name) {
         return hasOwnProp.call(this._tutorials, name) && this._tutorials[name];
@@ -134,6 +135,7 @@ class RootTutorial extends Tutorial {
 
     /**
      * Add a child tutorial to the root.
+     *
      * @param {module:jsdoc/tutorial.Tutorial} child - Child tutorial.
      */
     _addTutorial(child) {

--- a/packages/jsdoc/lib/jsdoc/tutorial/resolver.js
+++ b/packages/jsdoc/lib/jsdoc/tutorial/resolver.js
@@ -16,6 +16,7 @@ const finder = /^(.*)\.(x(?:ht)?ml|html?|md|markdown|json)$/i;
 
 /** checks if `conf` is the metadata for a single tutorial.
  * A tutorial's metadata has a property 'title' and/or a property 'children'.
+ *
  * @param {object} json - the object we want to test (typically from JSON.parse)
  * @returns {boolean} whether `json` could be the metadata for a tutorial.
  */
@@ -26,6 +27,7 @@ function isTutorialJSON(json) {
 
 /**
  * Root tutorial.
+ *
  * @type {module:jsdoc/tutorial.Root}
  */
 exports.root = new tutorial.RootTutorial();
@@ -76,6 +78,7 @@ function addTutorialConf(name, meta) {
 
 /**
  * Add a tutorial.
+ *
  * @param {module:jsdoc/tutorial.Tutorial} current - Tutorial to add.
  */
 exports.addTutorial = current => {
@@ -91,6 +94,7 @@ exports.addTutorial = current => {
 
 /**
  * Load tutorials from the given path.
+ *
  * @param {string} filepath - Tutorials directory.
  */
 exports.load = filepath => {

--- a/packages/jsdoc/lib/jsdoc/util/logger.js
+++ b/packages/jsdoc/lib/jsdoc/util/logger.js
@@ -21,7 +21,7 @@
  * + `%j`: JSON.
  *
  * @module jsdoc/util/logger
- * @extends module:events.EventEmitter
+ * @augments module:events.EventEmitter
  * @example
  * var logger = require('jsdoc/util/logger');
  *
@@ -118,7 +118,15 @@ const PREFIXES = {
     WARN: 'WARNING: '
 };
 
-// Add a prefix to a log message if necessary.
+/**
+ * Add a prefix to a log message if necessary.
+ *
+ * @param {Array.<*>} args - FIXME
+ * @param {string} prefix - FIXME
+ * @returns {Array.<*>} The prefix-updated list of `args`.
+ * (If `prefix` was falsey, or `args[0]` was not a string, then `args` is returned
+ * unmodified.)
+ */
 function addPrefix(args, prefix) {
     let updatedArgs;
 
@@ -130,7 +138,13 @@ function addPrefix(args, prefix) {
     return updatedArgs || args;
 }
 
-// TODO: document events
+/**
+ * @todo Document events.
+ *
+ * @param {string} name - FIXME
+ * @param {Function} func - The function to wrap.
+ * @returns {Function} A wrapped `func`.
+ */
 function wrapLogFunction(name, func) {
     const eventName = `logger:${name}`;
     const upperCaseName = name.toUpperCase();
@@ -152,7 +166,11 @@ function wrapLogFunction(name, func) {
     };
 }
 
-// Print a message to STDOUT without a terminating newline.
+/**
+ * Print a message to STDOUT without a terminating newline.
+ *
+ * @param {...*} args - Arguments to print.
+ */
 function printToStdout(...args) {
     process.stdout.write( util.format(...args) );
 }
@@ -162,7 +180,7 @@ function printToStdout(...args) {
  *
  * @alias module:jsdoc/util/logger.debug
  * @param {string} message - The message to log.
- * @param {...*=} values - The values that will replace the message's placeholders.
+ * @param {...*} [values] - The values that will replace the message's placeholders.
  */
 logger.debug = wrapLogFunction('debug', console.info);
 /**
@@ -171,7 +189,7 @@ logger.debug = wrapLogFunction('debug', console.info);
  *
  * @alias module:jsdoc/util/logger.printDebug
  * @param {string} message - The message to log.
- * @param {...*=} values - The values that will replace the message's placeholders.
+ * @param {...*} [values] - The values that will replace the message's placeholders.
  */
 logger.printDebug = wrapLogFunction('debug', printToStdout);
 /**
@@ -179,7 +197,7 @@ logger.printDebug = wrapLogFunction('debug', printToStdout);
  *
  * @alias module:jsdoc/util/logger.error
  * @param {string} message - The message to log.
- * @param {...*=} values - The values that will replace the message's placeholders.
+ * @param {...*} [values] - The values that will replace the message's placeholders.
  */
 logger.error = wrapLogFunction('error', console.error);
 /**
@@ -187,7 +205,7 @@ logger.error = wrapLogFunction('error', console.error);
  *
  * @alias module:jsdoc/util/logger.fatal
  * @param {string} message - The message to log.
- * @param {...*=} values - The values that will replace the message's placeholders.
+ * @param {...*} [values] - The values that will replace the message's placeholders.
  */
 logger.fatal = wrapLogFunction('fatal', console.error);
 /**
@@ -195,7 +213,7 @@ logger.fatal = wrapLogFunction('fatal', console.error);
  *
  * @alias module:jsdoc/util/logger.info
  * @param {string} message - The message to log.
- * @param {...*=} values - The values that will replace the message's placeholders.
+ * @param {...*} [values] - The values that will replace the message's placeholders.
  */
 logger.info = wrapLogFunction('info', console.info);
 /**
@@ -204,7 +222,7 @@ logger.info = wrapLogFunction('info', console.info);
  *
  * @alias module:jsdoc/util/logger.printInfo
  * @param {string} message - The message to log.
- * @param {...*=} values - The values that will replace the message's placeholders.
+ * @param {...*} [values] - The values that will replace the message's placeholders.
  */
 logger.printInfo = wrapLogFunction('info', printToStdout);
 /**
@@ -212,7 +230,7 @@ logger.printInfo = wrapLogFunction('info', printToStdout);
  *
  * @alias module:jsdoc/util/logger.verbose
  * @param {string} message - The message to log.
- * @param {...*=} values - The values that will replace the message's placeholders.
+ * @param {...*} [values] - The values that will replace the message's placeholders.
  */
 logger.verbose = wrapLogFunction('verbose', console.info);
 /**
@@ -221,7 +239,7 @@ logger.verbose = wrapLogFunction('verbose', console.info);
  *
  * @alias module:jsdoc/util/logger.printVerbose
  * @param {string} message - The message to log.
- * @param {...*=} values - The values that will replace the message's placeholders.
+ * @param {...*} [values] - The values that will replace the message's placeholders.
  */
 logger.printVerbose = wrapLogFunction('verbose', printToStdout);
 /**
@@ -229,7 +247,7 @@ logger.printVerbose = wrapLogFunction('verbose', printToStdout);
  *
  * @alias module:jsdoc/util/logger.warn
  * @param {string} message - The message to log.
- * @param {...*=} values - The values that will replace the message's placeholders.
+ * @param {...*} [values] - The values that will replace the message's placeholders.
  */
 logger.warn = wrapLogFunction('warn', console.warn);
 
@@ -247,7 +265,7 @@ logger.setLevel = function(level) {
  * Get the current log level.
  *
  * @alias module:jsdoc/util/logger.getLevel
- * @return {module:jsdoc/util/logger.LEVELS} The current log level.
+ * @returns {module:jsdoc/util/logger.LEVELS} The current log level.
  */
 logger.getLevel = function() {
     return logLevel;

--- a/packages/jsdoc/lib/jsdoc/util/markdown.js
+++ b/packages/jsdoc/lib/jsdoc/util/markdown.js
@@ -1,5 +1,6 @@
 /**
  * Provides access to Markdown-related functions.
+ *
  * @module jsdoc/util/markdown
  */
 const env = require('jsdoc/env');
@@ -11,7 +12,8 @@ const path = require('jsdoc/path');
 
 /**
  * Enumeration of Markdown parsers that are available.
- * @enum {String}
+ *
+ * @enum {string}
  */
 const parserNames = {
     /**
@@ -43,7 +45,7 @@ const parserNames = {
  * parser.
  *
  * @param {string} source - The source text to sanitize.
- * @return {string} The source text, where underscores within inline tags have been protected with a
+ * @returns {string} The source text, where underscores within inline tags have been protected with a
  * preceding backslash (e.g., `\_`). The `marked` parser will strip the backslash and protect the
  * underscore.
  */
@@ -55,7 +57,7 @@ function escapeUnderscores(source) {
  * Escape HTTP/HTTPS URLs so that they are not automatically converted to HTML links.
  *
  * @param {string} source - The source text to escape.
- * @return {string} The source text with escape characters added to HTTP/HTTPS URLs.
+ * @returns {string} The source text with escape characters added to HTTP/HTTPS URLs.
  */
 function escapeUrls(source) {
     return source.replace(/(https?):\/\//g, '$1:\\/\\/');
@@ -65,7 +67,7 @@ function escapeUrls(source) {
  * Unescape HTTP/HTTPS URLs after Markdown parsing is complete.
  *
  * @param {string} source - The source text to unescape.
- * @return {string} The source text with escape characters removed from HTTP/HTTPS URLs.
+ * @returns {string} The source text with escape characters removed from HTTP/HTTPS URLs.
  */
 function unescapeUrls(source) {
     return source.replace(/(https?):\\\/\\\//g, '$1://');
@@ -75,7 +77,7 @@ function unescapeUrls(source) {
  * Escape backslashes within inline tags so that they are not stripped.
  *
  * @param {string} source - The source text to escape.
- * @return {string} The source text with backslashes escaped within inline tags.
+ * @returns {string} The source text with backslashes escaped within inline tags.
  */
 function escapeInlineTagBackslashes(source) {
     return source.replace(/\{@[^}\r\n]+\}/g, wholeMatch => wholeMatch.replace(/\\/g, '\\\\'));
@@ -85,7 +87,7 @@ function escapeInlineTagBackslashes(source) {
  * Escape characters in text within a code block.
  *
  * @param {string} source - The source text to escape.
- * @return {string} The escaped source text.
+ * @returns {string} The escaped source text.
  */
 function escapeCode(source) {
     return source.replace(/</g, '&lt;')
@@ -98,7 +100,7 @@ function escapeCode(source) {
  *
  * @param {string} code - The code snippet.
  * @param {string?} language - The language of the code snippet.
- * @return {string} The wrapped code snippet.
+ * @returns {string} The wrapped code snippet.
  */
 function highlight(code, language) {
     let classString;
@@ -123,7 +125,7 @@ function highlight(code, language) {
  * entities.
  *
  * @param {string} source - The source text to unencode.
- * @return {string} The source text with HTML entity `&quot;` converted back to standard quotes.
+ * @returns {string} The source text with HTML entity `&quot;` converted back to standard quotes.
  */
 function unencodeQuotes(source) {
     return source.replace(/\{@[^}\r\n]+\}/g, wholeMatch => wholeMatch.replace(/&quot;/g, '"'));
@@ -133,8 +135,8 @@ function unencodeQuotes(source) {
  * Get the appropriate function for applying syntax highlighting to text, based on the user's
  * Markdown configuration settings.
  *
- * @param {Object} conf - The user's Markdown configuration settings.
- * @return {function} The highlighter function.
+ * @param {object} conf - The user's Markdown configuration settings.
+ * @returns {Function} The highlighter function.
  */
 function getHighlighter(conf) {
     let highlighter;
@@ -179,8 +181,8 @@ function getHighlighter(conf) {
  * the specified parser to transform the Markdown source to HTML, then returns the HTML as a string.
  *
  * @private
- * @param {String} parserName The name of the selected parser.
- * @param {Object} [conf] Configuration for the selected parser, if any.
+ * @param {string} parserName The name of the selected parser.
+ * @param {object} [conf] Configuration for the selected parser, if any.
  * @returns {Function} A function that accepts Markdown source, feeds it to the selected parser, and
  * returns the resulting HTML.
  */
@@ -270,7 +272,7 @@ function getParseFunction(parserName, conf) {
  * source. The function uses the parser specified in `conf.json` to transform the Markdown source to
  * HTML, then returns the HTML as a string.
  *
- * @returns {function} A function that accepts Markdown source, feeds it to the selected parser, and
+ * @returns {Function} A function that accepts Markdown source, feeds it to the selected parser, and
  * returns the resulting HTML.
  */
 exports.getParser = () => {

--- a/packages/jsdoc/lib/jsdoc/util/templateHelper.js
+++ b/packages/jsdoc/lib/jsdoc/util/templateHelper.js
@@ -20,8 +20,11 @@ const containers = ['class', 'module', 'external', 'namespace', 'mixin', 'interf
 
 let tutorials;
 
-/** Sets tutorials map.
-    @param {jsdoc.tutorial.Tutorial} root - Root tutorial node.
+
+/**
+ * Sets tutorials map.
+ *
+ * @param {module:jsdoc/tutorial.Tutorial} root - Root tutorial node.
  */
 exports.setTutorials = root => {
     tutorials = root;
@@ -58,6 +61,10 @@ const registerId = exports.registerId = (longname, fragment) => {
     linkMap.longnameToId[longname] = fragment;
 };
 
+/**
+ * @param {*} kind - FIXME
+ * @returns {string} The namespace, or an empty string if `kind` is not a namespace.
+ */
 function getNamespace(kind) {
     if (dictionary.isNamespace(kind)) {
         return `${kind}:`;
@@ -66,6 +73,10 @@ function getNamespace(kind) {
     return '';
 }
 
+/**
+ * @param {module:jsdoc/doclet.Doclet} doclet - The doclet to format.
+ * @returns {string} FIXME
+ */
 function formatNameForLink(doclet) {
     let newName = getNamespace(doclet.kind) + (doclet.name || '') + (doclet.variation || '');
     const scopePunc = exports.scopeToPunc[doclet.scope] || '';
@@ -80,6 +91,11 @@ function formatNameForLink(doclet) {
     return newName;
 }
 
+/**
+ * @param {string} filename - A filename.
+ * @param {string} str - The string to use as the value.
+ * @returns {string} The new `filename`, used (lower-case) as a key in `files`.
+ */
 function makeUniqueFilename(filename, str) {
     let key = filename.toLowerCase();
     let nonUnique = true;
@@ -111,12 +127,13 @@ function makeUniqueFilename(filename, str) {
  * Filenames are cached to ensure that they are used only once. For example, if the same string is
  * passed in twice, two different filenames will be returned.
  *
- * Also, filenames are not considered unique if they are capitalized differently but are otherwise
- * identical.
+ * This function is case-sensitive when considering filename. (Filenames will not be
+ * considered unique if they differ in case, but are otherwise
+ * identical.)
  *
  * @function
- * @param {string} str The string to convert.
- * @return {string} The filename to use for the string.
+ * @param {string} str - The string to convert.
+ * @returns {string} The filename to use for the string.
  */
 const getUniqueFilename = exports.getUniqueFilename = str => {
     const namespaces = dictionary.getNamespaces().join('|');
@@ -143,9 +160,12 @@ const getUniqueFilename = exports.getUniqueFilename = str => {
 };
 
 /**
- * Get a longname's filename if one has been registered; otherwise, generate a unique filename, then
- * register the filename.
+ * Get a longname's filename if one has been registered. Otherwise, generate a unique
+ * filename, then register the filename.
+ *
  * @private
+ * @param {string} longname - The longname to try and look up.
+ * @returns {string} A file URL.
  */
 function getFilename(longname) {
     let fileUrl;
@@ -167,14 +187,18 @@ function getFilename(longname) {
  *
  * @private
  * @param {module:jsdoc/doclet.Doclet} doclet - The doclet for the symbol.
- * @return {boolean} `true` if the symbol is the only symbol exported by a module; otherwise,
- * `false`.
+ * @returns {boolean} Whether or not the symbol is the only symbol exported by a module.
  */
 function isModuleExports(doclet) {
     return doclet.longname && doclet.longname === doclet.name &&
         doclet.longname.indexOf(MODULE_NAMESPACE) === 0 && doclet.kind !== 'module';
 }
 
+/**
+ * @param {string} filename - The filename
+ * @param {string} id - FIXME
+ * @returns {string} A processed `id`.
+ */
 function makeUniqueId(filename, id) {
     let key;
     let nonUnique = true;
@@ -202,9 +226,13 @@ function makeUniqueId(filename, id) {
 }
 
 /**
- * Get a doclet's ID if one has been registered; otherwise, generate a unique ID, then register
- * the ID.
+ * Get a doclet's ID if one has been registered; otherwise, generate a unique ID, then
+ * register the ID.
+ *
  * @private
+ * @param {string} longname - FIXME
+ * @param {string} id - FIXME
+ * @returns {string} A processed `id`.
  */
 function getId(longname, id) {
     if ( hasOwnProp.call(longnameToId, longname) ) {
@@ -228,10 +256,10 @@ function getId(longname, id) {
  * Identifiers are not considered unique if they are capitalized differently but are otherwise
  * identical.
  *
- * @method
+ * @function
  * @param {string} filename - The file in which the identifier will be used.
- * @param {string} doclet - The doclet to convert.
- * @return {string} A unique identifier based on the file and doclet.
+ * @param {module:jsdoc/doclet.Doclet} doclet - The doclet to convert.
+ * @returns {string} A unique identifier based on the file and doclet.
  */
 exports.getUniqueId = makeUniqueId;
 
@@ -244,6 +272,10 @@ const htmlsafe = exports.htmlsafe = str => {
         .replace(/</g, '&lt;');
 };
 
+/**
+ * @param {string} longname - FIXME
+ * @returns {*} FIXME
+ */
 function parseType(longname) {
     let err;
 
@@ -258,6 +290,12 @@ function parseType(longname) {
     }
 }
 
+/**
+ * @param {object} parsedType - FIXME
+ * @param {object} cssClass - FIXME
+ * @param {object} stringifyLinkMap - FIXME
+ * @returns {string} The stringified type.
+ */
 function stringifyType(parsedType, cssClass, stringifyLinkMap) {
     return require('catharsis').stringify(parsedType, {
         cssClass: cssClass,
@@ -266,15 +304,27 @@ function stringifyType(parsedType, cssClass, stringifyLinkMap) {
     });
 }
 
+/**
+ * @param {string} text - Text to check.
+ * @returns {boolean} Does `text` have a URL prefix?
+ */
 function hasUrlPrefix(text) {
     return (/^(http|ftp)s?:\/\//).test(text);
 }
 
+/**
+ * @param {object} expr - An expression to check.
+ * @returns {boolean} Is `expr` a complex type?
+ */
 function isComplexTypeExpression(expr) {
     // record types, type unions, and type applications all count as "complex"
     return /^{.+}$/.test(expr) || /^.+\|.+$/.test(expr) || /^.+<.+>$/.test(expr);
 }
 
+/**
+ * @param {object} fragmentId - FIXME
+ * @returns {string} FIXME
+ */
 function fragmentHash(fragmentId) {
     if (!fragmentId) {
         return '';
@@ -283,6 +333,10 @@ function fragmentHash(fragmentId) {
     return `#${fragmentId}`;
 }
 
+/**
+ * @param {string} longname - FIXME
+ * @returns {string} The shortened name of `longname`.
+ */
 function getShortName(longname) {
     return name.shorten(longname).name;
 }
@@ -299,19 +353,19 @@ function getShortName(longname) {
  * is ignored for type applications.
  *
  * @param {string} longname - The longname (or URL) that is the target of the link.
- * @param {string=} linkText - The text to display for the link, or `longname` if no text is
+ * @param {string} [linkText=longname] - The text to display for the link, or `longname` if no text is
  * provided.
- * @param {Object} options - Options for building the link.
- * @param {string=} options.cssClass - The CSS class (or classes) to include in the link's `<a>`
+ * @param {object} options - Options for building the link.
+ * @param {string} [options.cssClass] - The CSS class (or classes) to include in the link's `<a>`
  * tag.
- * @param {string=} options.fragmentId - The fragment identifier (for example, `name` in
+ * @param {string=} [options.fragmentId] - The fragment identifier (for example, `name` in
  * `foo.html#name`) to append to the link target.
- * @param {string=} options.linkMap - The link map in which to look up the longname.
- * @param {boolean=} options.monospace - Indicates whether to display the link text in a monospace
+ * @param {string} [options.linkMap] - The link map in which to look up the longname.
+ * @param {boolean} [options.monospace] - Indicates whether to display the link text in a monospace
  * font.
- * @param {boolean=} options.shortenName - Indicates whether to extract the short name from the
+ * @param {boolean} [options.shortenName] - Indicates whether to extract the short name from the
  * longname and display the short name in the link text. Ignored if `linkText` is specified.
- * @return {string} The HTML link, or the link text if the link is not available.
+ * @returns {string} The HTML link, or the link text if the link is not available.
  */
 function buildLink(longname, linkText, options) {
     const classString = options.cssClass ? ` class="${options.cssClass}"` : '';
@@ -371,7 +425,7 @@ function buildLink(longname, linkText, options) {
  * @param {string=} cssClass - The CSS class (or classes) to include in the link's `<a>` tag.
  * @param {string=} fragmentId - The fragment identifier (for example, `name` in `foo.html#name`) to
  * append to the link target.
- * @return {string} The HTML link, or a plain-text string if the link is not available.
+ * @returns {string} The HTML link, or a plain-text string if the link is not available.
  */
 const linkto = exports.linkto = (longname, linkText, cssClass, fragmentId) => buildLink(longname, linkText, {
     cssClass: cssClass,
@@ -379,6 +433,11 @@ const linkto = exports.linkto = (longname, linkText, cssClass, fragmentId) => bu
     linkMap: longnameToUrl
 });
 
+/**
+ * @param {module:jsdoc/tag.Tag} tag - FIXME
+ * @param {string} text - FIXME
+ * @returns {boolean} FIXME
+ */
 function useMonospace(tag, text) {
     let cleverLinks;
     let monospaceLinks;
@@ -405,6 +464,10 @@ function useMonospace(tag, text) {
     return result || false;
 }
 
+/**
+ * @param {string} text - The text to split
+ * @returns {object} Containing `linkText` and `target` properties.
+ */
 function splitLinkText(text) {
     let linkText;
     let target;
@@ -457,13 +520,13 @@ const tutorialToUrl = exports.tutorialToUrl = tutorial => {
  *
  * @function
  * @todo Deprecate missingOpts once we have a better error-reporting mechanism.
- * @param {string} tutorial The name of the tutorial.
- * @param {string} content The link text to use.
- * @param {object} [missingOpts] Options for displaying the name of a missing tutorial.
- * @param {string} missingOpts.classname The CSS class to wrap around the tutorial name.
- * @param {string} missingOpts.prefix The prefix to add to the tutorial name.
- * @param {string} missingOpts.tag The tag to wrap around the tutorial name.
- * @return {string} An HTML link to the tutorial, or the name of the tutorial with the specified
+ * @param {string} tutorial - The name of the tutorial.
+ * @param {string} content - The link text to use.
+ * @param {object} [missingOpts] - Options for displaying the name of a missing tutorial.
+ * @param {string} missingOpts.classname - The CSS class to wrap around the tutorial name.
+ * @param {string} missingOpts.prefix - The prefix to add to the tutorial name.
+ * @param {string} missingOpts.tag - The tag to wrap around the tutorial name.
+ * @returns {string} An HTML link to the tutorial, or the name of the tutorial with the specified
  * options.
  */
 const toTutorial = exports.toTutorial = (tutorial, content, missingOpts) => {
@@ -503,6 +566,9 @@ const toTutorial = exports.toTutorial = (tutorial, content, missingOpts) => {
     return `<a href="${tutorialToUrl(tutorial)}">${content}</a>`;
 };
 
+/**
+ * @returns {boolean} Should longnames be shortened?
+ */
 function shouldShortenLongname() {
     if (env.conf && env.conf.templates && env.conf.templates.useShortNamesInLinks) {
         return true;
@@ -515,11 +581,16 @@ function shouldShortenLongname() {
  * Find `{@link ...}` and `{@tutorial ...}` inline tags and turn them into HTML links.
  *
  * @param {string} str - The string to search for `{@link ...}` and `{@tutorial ...}` tags.
- * @return {string} The linkified text.
+ * @returns {string} The linkified text.
  */
-exports.resolveLinks = str => {
+exports.resolveLinks = (str) => {
     let replacers;
 
+    /**
+     * @param {string} string - FIXME
+     * @param {module:jsdoc/tag.Tag} completeTag - FIXME
+     * @returns {object} FIXME
+     */
     function extractLeadingText(string, completeTag) {
         const tagIndex = string.indexOf(completeTag);
         let leadingText = null;
@@ -543,6 +614,11 @@ exports.resolveLinks = str => {
         };
     }
 
+    /**
+     * @param {string} string - FIXME
+     * @param {object} fixMyName - FIXME
+     * @returns {string} FIXME
+     */
     function processLink(string, {completeTag, text, tag}) {
         const leading = extractLeadingText(string, completeTag);
         let linkText = leading.leadingText;
@@ -565,6 +641,11 @@ exports.resolveLinks = str => {
         }) );
     }
 
+    /**
+     * @param {string} string - FIXME
+     * @param {object} fixMyName - FIXME
+     * @returns {string} FIXME
+     */
     function processTutorial(string, {completeTag, text}) {
         const leading = extractLeadingText(string, completeTag);
 
@@ -586,8 +667,10 @@ exports.resolveLinks = str => {
 /**
  * Convert tag text like `Jane Doe <jdoe@example.org>` into a `mailto:` link.
  *
+ * @function
+ *
  * @param {string} str - The tag text.
- * @return {string} The linkified text.
+ * @returns {string} The linkified text.
  */
 exports.resolveAuthorLinks = str => {
     let author = '';
@@ -611,11 +694,12 @@ exports.resolveAuthorLinks = str => {
  * Find items in a TaffyDB database that match the specified key-value pairs.
  *
  * @function
- * @param {TAFFY} data The TaffyDB database to search.
- * @param {object|function} spec Key-value pairs to match against (for example,
+ *
+ * @param {module:taffydb.taffy} data The TaffyDB database to search.
+ * @param {object|Function} spec Key-value pairs to match against (for example,
  * `{ longname: 'foo' }`), or a function that returns `true` if a value matches or `false` if it
  * does not match.
- * @return {array<object>} The matching items.
+ * @returns {Array.<object>} The matching items.
  */
 const find = exports.find = (data, spec) => data(spec).get();
 
@@ -629,8 +713,9 @@ const find = exports.find = (data, spec) => data(spec).get();
  * + Modules
  * + Namespaces
  * + Events
- * @param {TAFFY} data The TaffyDB database to search.
- * @return {object} An object with `classes`, `externals`, `globals`, `mixins`, `modules`,
+ *
+ * @param {module:taffydb.taffy} data The TaffyDB database to search.
+ * @returns {object} An object with `classes`, `externals`, `globals`, `mixins`, `modules`,
  * `events`, and `namespaces` properties. Each property contains an array of objects.
  */
 exports.getMembers = data => {
@@ -667,8 +752,9 @@ exports.getMembers = data => {
 /**
  * Retrieve the member attributes for a doclet (for example, `virtual`, `static`, and
  * `readonly`).
- * @param {object} d The doclet whose attributes will be retrieved.
- * @return {array<string>} The member attributes for the doclet.
+ *
+ * @param {module:jsdoc/doclet.Doclet} d - The doclet whose attributes will be retrieved.
+ * @returns {Array.<string>} The member attributes for the doclet.
  */
 exports.getAttribs = d => {
     const attribs = [];
@@ -722,9 +808,9 @@ exports.getAttribs = d => {
 /**
  * Retrieve links to allowed types for the member.
  *
- * @param {Object} d - The doclet whose types will be retrieved.
+ * @param {module:jsdoc/doclet.Doclet} d - The doclet whose types will be retrieved.
  * @param {string} [cssClass] - The CSS class to include in the `class` attribute for each link.
- * @return {Array.<string>} HTML links to allowed types for the member.
+ * @returns {Array.<string>} HTML links to allowed types for the member.
  */
 exports.getSignatureTypes = ({type}, cssClass) => {
     let types = [];
@@ -743,11 +829,12 @@ exports.getSignatureTypes = ({type}, cssClass) => {
 /**
  * Retrieve names of the parameters that the member accepts. If a value is provided for `optClass`,
  * the names of optional parameters will be wrapped in a `<span>` tag with that class.
+ *
  * @param {object} d The doclet whose parameter names will be retrieved.
  * @param {string} [optClass] The class to assign to the `<span>` tag that is wrapped around the
  * names of optional parameters. If a value is not provided, optional parameter names will not be
  * wrapped with a `<span>` tag. Must be a legal value for a CSS class name.
- * @return {array<string>} An array of parameter names, with or without `<span>` tags wrapping the
+ * @returns {Array.<string>} An array of parameter names, with or without `<span>` tags wrapping the
  * names of optional parameters.
  */
 exports.getSignatureParams = ({params}, optClass) => {
@@ -772,9 +859,9 @@ exports.getSignatureParams = ({params}, optClass) => {
 /**
  * Retrieve links to types that the member can return or yield.
  *
- * @param {Object} d - The doclet whose types will be retrieved.
+ * @param {module:jsdoc/doclet.Doclet} d - The doclet whose types will be retrieved.
  * @param {string} [cssClass] - The CSS class to include in the `class` attribute for each link.
- * @return {Array.<string>} HTML links to types that the member can return or yield.
+ * @returns {Array.<string>} HTML links to types that the member can return or yield.
  */
 exports.getSignatureReturns = ({yields, returns}, cssClass) => {
     let returnTypes = [];
@@ -799,9 +886,9 @@ exports.getSignatureReturns = ({yields, returns}, cssClass) => {
 /**
  * Retrieve an ordered list of doclets for a symbol's ancestors.
  *
- * @param {TAFFY} data - The TaffyDB database to search.
- * @param {Object} doclet - The doclet whose ancestors will be retrieved.
- * @return {Array.<module:jsdoc/doclet.Doclet>} A array of ancestor doclets, sorted from most to
+ * @param {module:taffydb.taffy} data - The TaffyDB database to search.
+ * @param {module:jsdoc/doclet.Doclet} doclet - The doclet whose ancestors will be retrieved.
+ * @returns {Array.<module:jsdoc/doclet.Doclet>} A array of ancestor doclets, sorted from most to
  * least distant.
  */
 exports.getAncestors = (data, doclet) => {
@@ -829,10 +916,10 @@ exports.getAncestors = (data, doclet) => {
 /**
  * Retrieve links to a member's ancestors.
  *
- * @param {TAFFY} data - The TaffyDB database to search.
- * @param {Object} doclet - The doclet whose ancestors will be retrieved.
+ * @param {module:taffydb.taffy} data - The TaffyDB database to search.
+ * @param {module:jsdoc/doclet.Doclet} doclet - The doclet whose ancestors will be retrieved.
  * @param {string} [cssClass] - The CSS class to include in the `class` attribute for each link.
- * @return {Array.<string>} HTML links to a member's ancestors.
+ * @returns {Array.<string>} HTML links to a member's ancestors.
  */
 exports.getAncestorLinks = (data, doclet, cssClass) => {
     const ancestors = exports.getAncestors(data, doclet);
@@ -856,7 +943,7 @@ exports.getAncestorLinks = (data, doclet, cssClass) => {
  * Iterates through all the doclets in `data`, ensuring that if a method `@listens` to an event,
  * then that event has a `listeners` array with the longname of the listener in it.
  *
- * @param {TAFFY} data - The TaffyDB database to search.
+ * @param {module:taffydb.taffy} data - The TaffyDB database to search.
  */
 exports.addEventListeners = data => {
     // just a cache to prevent me doing so many lookups
@@ -902,8 +989,9 @@ exports.addEventListeners = data => {
  * + Members of anonymous classes.
  * + Members tagged `@private`, unless the `private` option is enabled.
  * + Members tagged with anything other than specified by the `access` options.
- * @param {TAFFY} data The TaffyDB database to prune.
- * @return {TAFFY} The pruned database.
+ *
+ * @param {module:taffydb.taffy} data The TaffyDB database to prune.
+ * @returns {module:taffydb.taffy} The pruned database.
  */
 exports.prune = data => {
     data({undocumented: true}).remove();
@@ -941,7 +1029,7 @@ exports.prune = data => {
  * represents a method), the URL will consist of a filename and a fragment ID.
  *
  * @param {module:jsdoc/doclet.Doclet} doclet - The doclet that will be used to create the URL.
- * @return {string} The URL to the generated documentation for the doclet.
+ * @returns {string} The URL to the generated documentation for the doclet.
  */
 exports.createLink = doclet => {
     let fakeContainer;
@@ -994,11 +1082,11 @@ exports.createLink = doclet => {
  *
  * @function
  * @see module:jsdoc/name.longnamesToTree
- * @param {Array<string>} longnames - The longnames to convert into a tree.
- * @param {Object<string, module:jsdoc/doclet.Doclet>} doclets - The doclets to attach to a tree.
+ * @param {Array.<string>} longnames - The longnames to convert into a tree.
+ * @param {object<string, module:jsdoc/doclet.Doclet>} doclets - The doclets to attach to a tree.
  * Each property should be the longname of a doclet, and each value should be the doclet for that
  * longname.
- * @return {Object} A tree with information about each longname.
+ * @returns {object} A tree with information about each longname.
  */
 exports.longnamesToTree = name.longnamesToTree;
 

--- a/packages/jsdoc/plugins/commentsOnly.js
+++ b/packages/jsdoc/plugins/commentsOnly.js
@@ -1,6 +1,7 @@
 /**
  * Remove everything in a file except JSDoc-style comments. By enabling this plugin, you can
  * document source files that are not valid JavaScript (including source files for other languages).
+ *
  * @module plugins/commentsOnly
  */
 exports.handlers = {

--- a/packages/jsdoc/plugins/eventDumper.js
+++ b/packages/jsdoc/plugins/eventDumper.js
@@ -29,8 +29,8 @@ if (conf.exclude) {
 /**
  * Replace AST node objects in events with a placeholder.
  *
- * @param {Object} o - An object whose properties may contain AST node objects.
- * @return {Object} The modified object.
+ * @param {object} o - An object whose properties may contain AST node objects.
+ * @returns {object} The modified object.
  */
 function replaceNodeObjects(o) {
     const OBJECT_PLACEHOLDER = '<Object>';
@@ -58,7 +58,7 @@ function replaceNodeObjects(o) {
  * Get rid of unwanted crud in an event object.
  *
  * @param {object} e The event object.
- * @return {object} The fixed-up object.
+ * @returns {object} The fixed-up object.
  */
 function cleanse(e) {
     let result = {};

--- a/packages/jsdoc/plugins/markdown.js
+++ b/packages/jsdoc/plugins/markdown.js
@@ -22,6 +22,11 @@ const parse = require('jsdoc/util/markdown').getParser();
 let tags = [];
 let excludeTags = [];
 
+/**
+ * @param {object} tagName - FIXME
+ * @param {string} text - FIXME
+ * @returns {boolean} FIXME
+ */
 function shouldProcessString(tagName, text) {
     let shouldProcess = true;
 
@@ -35,9 +40,12 @@ function shouldProcessString(tagName, text) {
 
 /**
  * Process the markdown source in a doclet. The properties that should be processed are
- * configurable, but always include "author", "classdesc", "description", "exceptions", "params",
- * "properties",  "returns", and "see".  Handled properties can be bare strings, objects, or arrays
- * of objects.
+ * configurable, but always include "author", "classdesc", "description", "exceptions",
+ * "params", "properties",  "returns", and "see".
+ *
+ * Handled properties can be bare strings, objects, or arrays of objects.
+ *
+ * @param {module:jsdoc/doclet.Doclet} doclet - The doclet to process.
  */
 function process(doclet) {
     tags.forEach(tag => {

--- a/packages/jsdoc/plugins/overloadHelper.js
+++ b/packages/jsdoc/plugins/overloadHelper.js
@@ -37,6 +37,10 @@
 // lookup table of function doclets by longname
 let functionDoclets;
 
+/**
+ * @param {object} obj - FIXME
+ * @returns {boolean} Whether `obj` has unique values.
+ */
 function hasUniqueValues(obj) {
     let isUnique = true;
     const seen = [];
@@ -52,6 +56,10 @@ function hasUniqueValues(obj) {
     return isUnique;
 }
 
+/**
+ * @param {Array.<object>} params - params whose names to get.
+ * @returns {string} A single string containing comma-separated names of `params`.
+ */
 function getParamNames(params) {
     const names = [];
 
@@ -69,15 +77,26 @@ function getParamNames(params) {
     return names.length ? names.join(', ') : '';
 }
 
+/**
+ * @param {object} fixMyName - FIXME
+ * @returns {Array.<object>} FIXME
+ */
 function getParamVariation({params}) {
     return getParamNames(params || []);
 }
 
+/**
+ * @param {Array.<module:jsdoc/doclet.Doclet>} doclets - Doclets to get unique values for.
+ * @returns {object} FIXME
+ */
 function getUniqueVariations(doclets) {
     let counter = 0;
     const variations = {};
     const docletKeys = Object.keys(doclets);
 
+    /**
+     *
+     */
     function getUniqueNumbers() {
         docletKeys.forEach(doclet => {
             let newLongname;
@@ -95,6 +114,9 @@ function getUniqueVariations(doclets) {
         });
     }
 
+    /**
+     *
+     */
     function getUniqueNames() {
         // start by trying to preserve existing variations
         docletKeys.forEach(doclet => {
@@ -125,6 +147,10 @@ function getUniqueVariations(doclets) {
     return variations;
 }
 
+/**
+ * @param {module:jsdoc/doclet.Doclet} newDoclet - FIXME
+ * @returns {module:jsdoc/doclet.Doclet} A doclet with a unique longname.
+ */
 function ensureUniqueLongname(newDoclet) {
     const doclets = {
         oldDoclet: functionDoclets[newDoclet.longname],

--- a/packages/jsdoc/plugins/partial.js
+++ b/packages/jsdoc/plugins/partial.js
@@ -1,5 +1,5 @@
 /**
- * Adds support for reusable partial jsdoc files.
+ * Adds support for reusable partial JSDoc files.
  *
  * @module plugins/partial
  */
@@ -9,13 +9,15 @@ const path = require('path');
 
 exports.handlers = {
     /**
-     * Include a partial jsdoc
+     * Include a partial JSDoc.
      *
-     * @param e
-     * @param e.filename
-     * @param e.source
+     * @param {*} e - The event fired before parsing.
+     * @param {string} e.filename - The name of the file about to be parsed.
+     * @param {string} e.source - The contents of `e.filename`.
      * @example
-     *     @partial "partial_doc.jsdoc"
+     *  ```
+     *  @partial "partial_doc.jsdoc"
+     *  ```
      */
     beforeParse(e) {
         e.source = e.source.replace(/(@partial ".*")+/g, $ => {

--- a/packages/jsdoc/plugins/railsTemplate.js
+++ b/packages/jsdoc/plugins/railsTemplate.js
@@ -1,5 +1,5 @@
 /**
- * Strips the rails template tags from a js.erb file
+ * Strips the rails template tags from a `js.erb` file.
  *
  * @module plugins/railsTemplate
  */
@@ -7,9 +7,9 @@ exports.handlers = {
     /**
      * Remove rails tags from the source input (e.g. <% foo bar %>)
      *
-     * @param e
-     * @param e.filename
-     * @param e.source
+     * @param {*} e - The event fired before parsing.
+     * @param {string} e.filename - The name of the file about to be parsed.
+     * @param {string} e.source - The contents of `e.filename`.
      */
     beforeParse(e) {
         if (e.filename.match(/\.erb$/)) {

--- a/packages/jsdoc/plugins/sourcetag.js
+++ b/packages/jsdoc/plugins/sourcetag.js
@@ -5,17 +5,23 @@ const logger = require('jsdoc/util/logger');
 
 exports.handlers = {
     /**
-     * Support @source tag. Expected value like:
+     * Support the `@source` tag.
      *
-     *     { "filename": "myfile.js", "lineno": 123 }
+     * @example
+     *      // Expected value like:
+     *      { "filename": "myfile.js", "lineno": 123 }
      *
      * Modifies the corresponding meta values on the given doclet.
      *
      * WARNING: If you are using a JSDoc template that generates pretty-printed source files,
-     * such as JSDoc's default template, this plugin can cause JSDoc to crash. To fix this issue,
-     * update your template settings to disable pretty-printed source files.
+     * such as JSDoc's default template, this plugin can cause JSDoc to crash. To fix this
+     * issue, update your template settings to disable pretty-printed source files.
      *
-     * @source { "filename": "sourcetag.js", "lineno": 9 }
+     *```
+     *  @source { "filename": "sourcetag.js", "lineno": 9 }
+     *```
+     *
+     * @param {object} fixMyName - FIXME
      */
     newDoclet({doclet}) {
         let tags = doclet.tags;

--- a/packages/jsdoc/templates/default/publish.js
+++ b/packages/jsdoc/templates/default/publish.js
@@ -33,10 +33,18 @@ let view;
 
 let outdir = path.normalize(env.opts.destination);
 
+/**
+ * @param {*} spec - FIXME
+ * @returns {*} FIXME
+ */
 function find(spec) {
     return helper.find(data, spec);
 }
 
+/**
+ * @param {module:jsdoc/tutorial.Tutorial} tutorial - FIXME
+ * @returns {*} FIXME
+ */
 function tutoriallink(tutorial) {
     return helper.toTutorial(tutorial, null, {
         tag: 'em',
@@ -45,10 +53,19 @@ function tutoriallink(tutorial) {
     });
 }
 
+/**
+ * @param {module:jsdoc/doclet.Doclet} doclet - The doclet to get ancestor links for.
+ * @returns {*} FIXME
+ */
 function getAncestorLinks(doclet) {
     return helper.getAncestorLinks(data, doclet);
 }
 
+/**
+ * @param {module:jsdoc/doclet.Doclet} doclet - FIXME
+ * @param {object} hash - FIXME
+ * @returns {string} An HTML string for a link.
+ */
 function hashToLink(doclet, hash) {
     let url;
 
@@ -62,6 +79,13 @@ function hashToLink(doclet, hash) {
     return `<a href="${url}">${hash}</a>`;
 }
 
+/**
+ * @param {object} hash - FIXME
+ * @param {string} hash.kind - FIXME
+ * @param {object} hash.type - FIXME
+ * @param {object} hash.meta - FIXME
+ * @returns {boolean} Whether `hash` needs a signature.
+ */
 function needsSignature({kind, type, meta}) {
     let needsSig = false;
 
@@ -89,6 +113,12 @@ function needsSignature({kind, type, meta}) {
     return needsSig;
 }
 
+/**
+ * @param {object} hash - FIXME
+ * @param {boolean} hash.optional - FIXME
+ * @param {boolean} hash.nullable - FIXME
+ * @returns {Array} A list of signature attributes.
+ */
 function getSignatureAttributes({optional, nullable}) {
     const attributes = [];
 
@@ -106,6 +136,10 @@ function getSignatureAttributes({optional, nullable}) {
     return attributes;
 }
 
+/**
+ * @param {object} item - FIXME
+ * @returns {string} An HTML string.
+ */
 function updateItemName(item) {
     const attributes = getSignatureAttributes(item);
     let itemName = item.name || '';
@@ -121,10 +155,18 @@ function updateItemName(item) {
     return itemName;
 }
 
+/**
+ * @param {Array} params - A list of params to update.
+ * @returns {Array.<string>} An array of HTML strings.
+ */
 function addParamAttributes(params) {
     return params.filter(({name}) => name && !name.includes('.')).map(updateItemName);
 }
 
+/**
+ * @param {object} item - FIXME
+ * @returns {Array} FIXME
+ */
 function buildItemTypeStrings(item) {
     const types = [];
 
@@ -137,6 +179,11 @@ function buildItemTypeStrings(item) {
     return types;
 }
 
+/**
+ * @param {*} attribs - FIXME
+ * @returns {string} An `htmlsafe()` filtered string of the joined attributes (or an empty
+ * string if `attribs` was an empty array).
+ */
 function buildAttribsString(attribs) {
     let attribsString = '';
 
@@ -147,6 +194,10 @@ function buildAttribsString(attribs) {
     return attribsString;
 }
 
+/**
+ * @param {Array} items - FIXME
+ * @returns {Array} FIXME
+ */
 function addNonParamAttributes(items) {
     let types = [];
 
@@ -157,12 +208,18 @@ function addNonParamAttributes(items) {
     return types;
 }
 
+/**
+ * @param {object} f - FIXME
+ */
 function addSignatureParams(f) {
     const params = f.params ? addParamAttributes(f.params) : [];
 
     f.signature = `${f.signature || ''}(${params.join(', ')})`;
 }
 
+/**
+ * @param {object} f - FIXME
+ */
 function addSignatureReturns(f) {
     const attribs = [];
     let attribsString = '';
@@ -196,6 +253,9 @@ function addSignatureReturns(f) {
         `<span class="type-signature">${returnTypesString}</span>`;
 }
 
+/**
+ * @param {object} f - FIXME
+ */
 function addSignatureTypes(f) {
     const types = f.type ? buildItemTypeStrings(f) : [];
 
@@ -203,6 +263,9 @@ function addSignatureTypes(f) {
         `${types.length ? ` :${types.join('|')}` : ''}</span>`;
 }
 
+/**
+ * @param {object} f - FIXME
+ */
 function addAttribs(f) {
     const attribs = helper.getAttribs(f);
     const attribsString = buildAttribsString(attribs);
@@ -210,6 +273,11 @@ function addAttribs(f) {
     f.attribs = `<span class="type-signature">${attribsString}</span>`;
 }
 
+/**
+ * @param {object.<string, object>} files - A hash filenames and their properties.
+ * @param {string} commonPrefix - A string to remove from all `files[file].resolved` values.
+ * @returns {object} A modified `files` object with shorter `resolved` path values.
+ */
 function shortenPaths(files, commonPrefix) {
     Object.keys(files).forEach(file => {
         files[file].shortened = files[file].resolved.replace(commonPrefix, '')
@@ -220,6 +288,11 @@ function shortenPaths(files, commonPrefix) {
     return files;
 }
 
+/**
+ * @param {module:jsdoc/doclet.Doclet} doclet - The doclet to extract the `meta` path from.
+ * @param {*} doclet.meta - The object to resolve from a path and filename into a string.
+ * @returns {?string} The resolved filename, or `null` if the doclet had no `meta` property.
+ */
 function getPathFromDoclet({meta}) {
     if (!meta) {
         return null;
@@ -230,6 +303,12 @@ function getPathFromDoclet({meta}) {
         meta.filename;
 }
 
+/**
+ * @param {string} title - The title to generate.
+ * @param {*} docs - FIXME
+ * @param {string} filename - The filename to write to.
+ * @param {boolean} resolveLinks - Whether to turn `{@link …}` tags into HTML links.
+ */
 function generate(title, docs, filename, resolveLinks) {
     let docData;
     let html;
@@ -253,6 +332,10 @@ function generate(title, docs, filename, resolveLinks) {
     fs.writeFileSync(outpath, html, 'utf8');
 }
 
+/**
+ * @param {object.<string, object>} sourceFiles - A hash of (source) files and their properties.
+ * @param {string} [encoding=utf8] - The encoding to use for the genreated files.
+ */
 function generateSourceFiles(sourceFiles, encoding = 'utf8') {
     Object.keys(sourceFiles).forEach(file => {
         let source;
@@ -315,6 +398,13 @@ function attachModuleSymbols(doclets, modules) {
     });
 }
 
+/**
+ * @param {Array} items - FIXME
+ * @param {string} itemHeading - The text to use for the HTML heading element.
+ * @param {object.<string, boolean>} itemsSeen - A hash of items already visited.
+ * @param {Function} linktoFn - The function to generate an HTML link element.
+ * @returns {string} An HTML string for navigation.
+ */
 function buildMemberNav(items, itemHeading, itemsSeen, linktoFn) {
     let nav = '';
 
@@ -347,27 +437,38 @@ function buildMemberNav(items, itemHeading, itemsSeen, linktoFn) {
     return nav;
 }
 
+/**
+ * @param {string} longName - FIXME
+ * @param {string} name - FIXME
+ * @returns {string} An HTML link.
+ */
 function linktoTutorial(longName, name) {
     return tutoriallink(name);
 }
 
+/**
+ * @param {string} longName - FIXME
+ * @param {string} name - FIXME
+ * @returns {string} An HTML link.
+ */
 function linktoExternal(longName, name) {
     return linkto(longName, name.replace(/(^"|"$)/g, ''));
 }
 
 /**
  * Create the navigation sidebar.
+ *
  * @param {object} members The members that will be used to create the sidebar.
- * @param {array<object>} members.classes
- * @param {array<object>} members.externals
- * @param {array<object>} members.globals
- * @param {array<object>} members.mixins
- * @param {array<object>} members.modules
- * @param {array<object>} members.namespaces
- * @param {array<object>} members.tutorials
- * @param {array<object>} members.events
- * @param {array<object>} members.interfaces
- * @return {string} The HTML for the navigation sidebar.
+ * @param {Array<object>} members.classes    - FIXME
+ * @param {Array<object>} members.externals  - FIXME
+ * @param {Array<object>} members.globals    - FIXME
+ * @param {Array<object>} members.mixins     - FIXME
+ * @param {Array<object>} members.modules    - FIXME
+ * @param {Array<object>} members.namespaces - FIXME
+ * @param {Array<object>} members.tutorials  - FIXME
+ * @param {Array<object>} members.events     - FIXME
+ * @param {Array<object>} members.interfaces - FIXME
+ * @returns {string} The HTML for the navigation sidebar.
  */
 function buildNav(members) {
     let globalNav;
@@ -407,9 +508,9 @@ function buildNav(members) {
 }
 
 /**
-    @param {TAFFY} taffyData See <http://taffydb.com/>.
-    @param {object} opts
-    @param {Tutorial} tutorials
+    @param {module:taffydb.taffy} taffyData See <http://taffydb.com>.
+    @param {object} opts - FIXME
+    @param {Array.<module:jsdoc/tutorial.Tutorial>} tutorials - FIXME
  */
 exports.publish = (taffyData, opts, tutorials) => {
     let classes;
@@ -627,7 +728,7 @@ exports.publish = (taffyData, opts, tutorials) => {
         }
     });
 
-    // do this after the urls have all been generated
+    // do this after the URLs have all been generated
     data().each(doclet => {
         doclet.ancestors = getAncestorLinks(doclet);
 
@@ -722,7 +823,13 @@ exports.publish = (taffyData, opts, tutorials) => {
         }
     });
 
-    // TODO: move the tutorial functions to templateHelper.js
+    /**
+     * @todo Move the tutorial functions to templateHelper.js
+     *
+     * @param {object} title - FIXME
+     * @param {object} tutorial - FIXME
+     * @param {string} filename - FIXME
+     */
     function generateTutorial(title, tutorial, filename) {
         const tutorialData = {
             title: title,
@@ -740,6 +847,9 @@ exports.publish = (taffyData, opts, tutorials) => {
     }
 
     // tutorials can have only one parent so there is no risk for loops
+    /**
+     * @param  {object} fixMyName - FIXME
+     */
     function saveChildren({children}) {
         children.forEach(child => {
             generateTutorial(`Tutorial: ${child.title}`, child, helper.tutorialToUrl(child.name));

--- a/packages/jsdoc/templates/default/static/scripts/linenumber.js
+++ b/packages/jsdoc/templates/default/static/scripts/linenumber.js
@@ -1,4 +1,4 @@
-/*global document */
+/* global document */
 (() => {
     const source = document.getElementsByClassName('prettyprint source linenums');
     let i = 0;

--- a/packages/jsdoc/templates/silent/publish.js
+++ b/packages/jsdoc/templates/silent/publish.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-empty-function, no-unused-vars */
 /**
-    @param {TAFFY} taffyData See <http://taffydb.com/>.
-    @param {object} opts
-    @param {Tutorial} tutorials
+ *  @param {module:taffydb.taffy} taffyData - See <http://taffydb.com/>
+ *  @param {object} opts - FIXME
+ *  @param {Array.<object>} tutorials - FIXME
  */
 exports.publish = (taffyData, opts, tutorials) => {};


### PR DESCRIPTION
Not all JSDoc comments are complete.  I marked incomplete comments with `@todo` or `FIXME`, so a simple `grep` or `ag` search for either string should make it easy to start filling in missing info bit-by-bit.

I don’t know the architecture of this project, so I did my best to use accurate `{type}` annoations in the JSDoc comments. If I wasn’t able to determine a given field’s type, I usually marked it `{object}`.

<!--
Before creating a pull request, please read our contributing guidelines and code of conduct:

https://github.com/jsdoc3/jsdoc/blob/master/CONTRIBUTING.md
https://github.com/jsdoc3/jsdoc/blob/master/CODE_OF_CONDUCT.md
-->

| Q                | A
| ---------------- | ---
| Bug fix?         | yes/no
| New feature?     | yes/no
| Breaking change? | yes/no
| Deprecations?    | yes/no
| Tests added?     | yes/no
| Fixed issues     | comma-separated list of issues fixed by the pull request, if any
| License          | Apache-2.0

<!-- Describe your changes below in as much detail as possible. -->
