### PR TITLE
Properly stringify function types with signature

### DIFF
--- a/packages/jsdoc/lib/jsdoc/tag/type.js
+++ b/packages/jsdoc/lib/jsdoc/tag/type.js
@@ -174,7 +174,15 @@ function getTypeStrings(parsedType, isOutermostType) {
             types.push('*');
             break;
         case TYPES.FunctionType:
-            types.push('function');
+            typeString = 'function';
+            if ( parsedType.params ) {
+                typeString += `(${parsedType.params.map(param => 
+                    catharsis.stringify(param)).join(', ')})`;
+            }
+            if ( parsedType.result ) {
+                typeString += `:${catharsis.stringify(parsedType.result)}`;
+            }
+            types.push(typeString);
             break;
         case TYPES.NameExpression:
             types.push(parsedType.name);


### PR DESCRIPTION
When function types contain a signature (e.g. `function(string, boolean): string`), `catharsis` parses them correctly, but the type handling in JSDoc stringified them as `function`, the signature was omitted.

With this change, the signature is added, too.  
 
Fixes #1510 .

<!--
Before creating a pull request, please read our contributing guidelines and code of conduct:

https://github.com/jsdoc3/jsdoc/blob/master/CONTRIBUTING.md
https://github.com/jsdoc3/jsdoc/blob/master/CODE_OF_CONDUCT.md
-->

| Q                | A
| ---------------- | ---
| Bug fix?         | yes/no
| New feature?     | yes/no
| Breaking change? | yes/no
| Deprecations?    | yes/no
| Tests added?     | yes/no
| Fixed issues     | comma-separated list of issues fixed by the pull request, if any
| License          | Apache-2.0

<!-- Describe your changes below in as much detail as possible. -->
