### PR TITLE
Add link to jsdoc-action GitHub Action in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ and customize your documentation. Here are a few of them:
 
 + [JSDoc Grunt plugin](https://github.com/krampstudio/grunt-jsdoc)
 + [JSDoc Gulp plugin](https://github.com/mlucool/gulp-jsdoc3)
++ [JSDoc GitHub Action](https://github.com/andstor/jsdoc-action)
 
 ### Other tools
 


### PR DESCRIPTION
<!--
Before creating a pull request, please read our contributing guidelines and code of conduct:

https://github.com/jsdoc3/jsdoc/blob/master/CONTRIBUTING.md
https://github.com/jsdoc3/jsdoc/blob/master/CODE_OF_CONDUCT.md
-->

| Q                | A
| ---------------- | ---
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Deprecations?    | no
| Tests added?     | no
| Fixed issues     | 
| License          | Apache-2.0

<!-- Describe your changes below in as much detail as possible. -->
This PR adds a **link** in the `README.md` file to a new [GitHub Action](https://github.com/features/actions) that I have created.
The Action is called `jsdoc-action` and is available at https://github.com/andstor/jsdoc-action.
It's also published at the GitHub marketplace at https://github.com/marketplace/actions/jsdoc-action.

It is a JavaScript GitHub Action to generate JavaScript documentation with JSDoc. The action can also easily be combined with other deployment actions, in order to automatically publish the generated documentation to for example GitHub Pages. JSDoc templates are also supported.

By using this GitHub Action, any project hosted at GitHub can enjoy a simple and straightforward process for setting up **automated** JavaScript documentation generation with JSDoc.

