### PR TITLE
Fix incorrect template example link

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ and customize your documentation. Here are a few of them:
 + [tui-jsdoc-template](https://github.com/nhnent/tui.jsdoc-template)
 ([example](https://nhnent.github.io/tui.jsdoc-template/latest/))
 + [better-docs](https://github.com/SoftwareBrothers/better-docs)
-([example](https://softwarebrothers.github.io/admin-bro-dev/index.html))
+([example](https://adminbro.com/docs.html))
 
 ### Build tools
 


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | no
| New feature?     | no
| Breaking change? | no
| Deprecations?    | no
| Tests added?     | no
| Fixed issues     | N/A
| License          | Apache-2.0

This change updates the linked example for the better-docs template, which has since been moved from https://softwarebrothers.github.io/admin-bro-dev/index.html to https://adminbro.com/docs.html
