### PR TITLE
Add option to add external links to source code

### DIFF
--- a/packages/jsdoc/conf.json.EXAMPLE
+++ b/packages/jsdoc/conf.json.EXAMPLE
@@ -11,7 +11,10 @@
         "cleverLinks": false,
         "monospaceLinks": false,
         "default": {
-            "outputSourceFiles": true
+            "outputSourceFiles": false,
+            "externalSourceLinks": {
+                "urlPrefix": "https://github.com/org/repo/blob/master/src/"
+            }
         }
     }
 }

--- a/packages/jsdoc/lib/jsdoc/util/templateHelper.js
+++ b/packages/jsdoc/lib/jsdoc/util/templateHelper.js
@@ -379,6 +379,16 @@ const linkto = exports.linkto = (longname, linkText, cssClass, fragmentId) => bu
     linkMap: longnameToUrl
 });
 
+exports.externalsourcelink = (path, linkText, lineno) => {
+    const externalSourceLinks = env.conf.templates.default.externalSourceLinks;
+    const url = externalSourceLinks.urlPrefix + path;
+    const fragmentId = lineno ? (externalSourceLinks.linenoPrefix || 'L') + lineno : null;
+
+    return buildLink(url, linkText || path, {
+        fragmentId: fragmentId
+    });
+};
+
 function useMonospace(tag, text) {
     let cleverLinks;
     let monospaceLinks;

--- a/packages/jsdoc/templates/default/publish.js
+++ b/packages/jsdoc/templates/default/publish.js
@@ -11,6 +11,7 @@ const template = require('jsdoc/template');
 
 const htmlsafe = helper.htmlsafe;
 const linkto = helper.linkto;
+const externalsourcelink = helper.externalsourcelink;
 const resolveAuthorLinks = helper.resolveAuthorLinks;
 const hasOwnProp = Object.prototype.hasOwnProperty;
 
@@ -438,6 +439,7 @@ exports.publish = (taffyData, opts, tutorials) => {
     let modules;
     let namespaces;
     let outputSourceFiles;
+    let externalSourceLinks;
     let packageInfo;
     let packages;
     const sourceFilePaths = [];
@@ -661,13 +663,18 @@ exports.publish = (taffyData, opts, tutorials) => {
     // output pretty-printed source files by default
     outputSourceFiles = conf.default && conf.default.outputSourceFiles !== false;
 
+    // link to externally hosted source files
+    externalSourceLinks = conf.default && conf.default.externalSourceLinks;
+
     // add template helpers
     view.find = find;
     view.linkto = linkto;
+    view.externalsourcelink = externalsourcelink;
     view.resolveAuthorLinks = resolveAuthorLinks;
     view.tutoriallink = tutoriallink;
     view.htmlsafe = htmlsafe;
     view.outputSourceFiles = outputSourceFiles;
+    view.externalSourceLinks = externalSourceLinks;
 
     // once for all
     view.nav = buildNav(members);

--- a/packages/jsdoc/templates/default/tmpl/details.tmpl
+++ b/packages/jsdoc/templates/default/tmpl/details.tmpl
@@ -114,6 +114,13 @@ if (data.defaultvalue && (data.defaultvaluetype === 'object' || data.defaultvalu
     </li></ul></dd>
     <?js } ?>
 
+    <?js if (data.meta && self.externalSourceLinks) {?>
+    <dt class="tag-source">External Source:</dt>
+    <dd class="tag-source"><ul class="dummy"><li>
+        <?js= self.externalsourcelink(meta.shortpath) ?>, <?js= self.externalsourcelink(meta.shortpath, 'line ' + meta.lineno, meta.lineno) ?>
+    </li></ul></dd>
+    <?js } ?>
+
     <?js if (data.tutorials && tutorials.length) {?>
     <dt class="tag-tutorial">Tutorials:</dt>
     <dd class="tag-tutorial">


### PR DESCRIPTION
<!--
Before creating a pull request, please read our contributing guidelines and code of conduct:

https://github.com/jsdoc3/jsdoc/blob/master/CONTRIBUTING.md
https://github.com/jsdoc3/jsdoc/blob/master/CODE_OF_CONDUCT.md
-->

| Q                | A
| ---------------- | ---
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Deprecations?    | no
| Tests added?     | no
| Fixed issues     | 
| License          | Apache-2.0

<!-- Describe your changes below in as much detail as possible. -->

This feature is meant as a compromise between copying all source code to the documentation directory (`outputSourceFiles = true`), and having no links to the source code at all (`outputSourceFiles = false`). Instead, this option allows you to link to an external source code repository (e.g. GitHub or GitLab).

- The `templates.default.externalSourceLinks.urlPrefix` option points to the location where the source code is hosted; the path of the file is appended to it.
- The `templates.default.externalSourceLinks.linenoPrefix` option defaults to `'L'` and refers to the `L` in `#L5` which points to line 5 on both GitHub and GitLab.

This was manually tested against v3, not v4, because I couldn't get `npm install`ing v4 from GitHub or a sibling directory to work. I also didn't see any tests for the `outputSourceFiles` feature, so I wasn't sure how to test this. All existing tests pass also in v4, though :man_shrugging:

Here is another example for how I intend to use this, automatically taking the repository url and version tag from package.json: https://github.com/twiss/openpgpjs/blob/v5-test/.jsdocrc.js. This should be convenient when updating the documentation whenever you release a new version, for example. That should also minimize the risk that the linked source code doesn't match the processed source code.