### PR TITLE
Skip over broken files when scanning the source

### DIFF
--- a/packages/jsdoc-util/lib/fs.js
+++ b/packages/jsdoc-util/lib/fs.js
@@ -5,6 +5,42 @@
 const _ = require('lodash');
 const klawSync = require('klaw-sync');
 const path = require('path');
+const fs = require('graceful-fs');
+
+// Create a `skipFileErrorFs` version of `fs`. This implements a filtered
+// version of `readdirSync` that skips files that will cause reading issues.
+// This helps us avoid falling flat on our face for example when processing
+// broken symlinks.
+let skipFileErrorFs = {};
+
+for (let fieldName in fs) {
+    if (Object.prototype.hasOwnProperty.call(fs, fieldName)) {
+        skipFileErrorFs[fieldName] = fs[fieldName];
+    }
+}
+
+skipFileErrorFs.readdirSync = ((dirPath, options = {}) => {
+    const paths = fs.readdirSync(dirPath, options);
+    let ret = [];
+    let stat;
+
+    for (var i = 0; i < paths.length; i += 1) {
+        const fullPath = dirPath + path.sep + paths[i];
+        try {
+            stat = fs.statSync(fullPath);
+        } catch (e) {
+            // Ignore error
+            console.log('Skipping file %s due to reading error', fullPath)
+            stat = null;
+        }
+
+        if (stat) {
+            ret.push(paths[i]);
+        }
+    }
+
+    return ret;
+});
 
 exports.lsSync = ((dir, opts = {}) => {
     const depth = _.has(opts, 'depth') ? opts.depth : -1;
@@ -12,7 +48,8 @@ exports.lsSync = ((dir, opts = {}) => {
     const files = klawSync(dir, {
         depthLimit: depth,
         filter: (f => !path.basename(f.path).startsWith('.')),
-        nodir: true
+        nodir: true,
+        fs: skipFileErrorFs
     });
 
     return files.map(f => f.path);

--- a/packages/jsdoc/test/fixtures/src/broken-symlink.js
+++ b/packages/jsdoc/test/fixtures/src/broken-symlink.js
@@ -1,0 +1,1 @@
+broken-synlink.js


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Deprecations?    | no
| Tests added?     | yes
| Fixed issues     | #1623 
| License          | Apache-2.0

<!-- Describe your changes below in as much detail as possible. -->

This fixes the bug #1623 and other similar issues.

When scanning source code, the previous behaviour was to trip up on any issue that `statSync` may raise. This can particularly happen for circular and broken symlinks.

The fix addresses this by creating a mock version of `fs` that does not even return such broken files from `readdirSync`.

The alternative fix would be to raise this on the `klaw-sync` package, but that might be a breaking change for the packages that depend on it.