### PR TITLE
fix: Check range when set module scope member

### DIFF
--- a/packages/jsdoc/lib/jsdoc/src/handlers.js
+++ b/packages/jsdoc/lib/jsdoc/src/handlers.js
@@ -14,8 +14,10 @@ class CurrentModule {
         this.doclet = doclet;
         this.longname = doclet.longname;
         this.originalName = doclet.meta.code.name || '';
+        this.range = doclet.meta.range || [0, Number.MAX_SAFE_INTEGER];
     }
 }
+
 function filterByLongname({longname}) {
     // you can't document prototypes
     if ( /#$/.test(longname) ) {
@@ -80,12 +82,19 @@ function setCurrentModule(doclet) {
     }
 }
 
+function isInModule(doclet) {
+    return currentModule && currentModule.longname !== doclet.name &&
+           doclet.meta && doclet.meta.range &&
+           currentModule.range[0] <= doclet.meta.range[0] &&
+           currentModule.range[1] >= doclet.meta.range[1];
+}
+
 function setModuleScopeMemberOf(parser, doclet) {
     let parentDoclet;
     let skipMemberof;
 
     // handle module symbols that are _not_ assigned to module.exports
-    if (currentModule && currentModule.longname !== doclet.name) {
+    if (isInModule(doclet)) {
         if (!doclet.scope) {
             // is this a method definition? if so, we usually get the scope from the node directly
             if (doclet.meta && doclet.meta.code && doclet.meta.code.node &&


### PR DESCRIPTION
Record module range when saving current module, and check if doclet in
range when call `setModuleScopeMemberOf` function.

<!--
Before creating a pull request, please read our contributing guidelines and code of conduct:

https://github.com/jsdoc3/jsdoc/blob/master/CONTRIBUTING.md
https://github.com/jsdoc3/jsdoc/blob/master/CODE_OF_CONDUCT.md
-->

| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Deprecations?    | yes
| Tests added?     | no
| Fixed issues     | list below
| License          | Apache-2.0

<!-- Describe your changes below in as much detail as possible. -->

When walking through AST, vistor will treat the enum as module, which will cause wrong full name for the next element.
For example:

```javascript
/*eslint-disable block-scoped-var, id-length, no-control-regex, no-magic-numbers, no-prototype-builtins, no-redeclare, no-shadow, no-var, sort-vars*/
"use strict";

var $protobuf = require("protobufjs/minimal");

// Exported root namespace
var $root = $protobuf.roots["default"] || ($protobuf.roots["default"] = {});

/**
 * MyEnum enum.
 * @exports MyEnum
 * @enum {number}
 * @property {number} UNKNOWN=0 UNKNOWN value
 */
$root.MyEnum = (function () {
  var valuesById = {},
    values = Object.create(valuesById);
  values[(valuesById[0] = "UNKNOWN")] = 0;
  return values;
})();

$root.MyMessage2 = (function () {
  /**
   * Properties of a MyMessage2.
   * @exports IMyMessage2
   * @interface IMyMessage2
   */

  /**
   * Constructs a new MyMessage2.
   * @exports MyMessage2
   * @classdesc Represents a MyMessage2.
   * @implements IMyMessage2
   * @constructor
   * @param {IMyMessage2=} [properties] Properties to set
   */
  function MyMessage2(properties) {
    if (properties)
      for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
        if (properties[keys[i]] != null) this[keys[i]] = properties[keys[i]];
  }

  return MyMessage2;
})();

module.exports = $root;
```

After visit `MyEnum`, the `currentModule` will become `module:MyEnum`, and the longname of `IMyMessage2` will become `module:MyEnum~IMyMessage2` even if it does not belong to `MyEnum`.

Here, we need to check if current element is out of current module, if it is, the branch should not be executed.