### PR TITLE
docs: add clean-jsdoc-theme in templates section

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ and customize your documentation. Here are a few of them:
   ([example](https://nhnent.github.io/tui.jsdoc-template/latest/))
 - [better-docs](https://github.com/SoftwareBrothers/better-docs)
   ([example](https://softwarebrothers.github.io/admin-bro-dev/index.html))
+- [clean-jsdoc-theme](https://github.com/ankitskvmdam/clean-jsdoc-theme)
+  ([example](https://ankdev.me/clean-jsdoc-theme))
 
 ### Build tools
 


### PR DESCRIPTION
<!--
Before creating a pull request, please read our contributing guidelines and code of conduct:

https://github.com/jsdoc3/jsdoc/blob/master/CONTRIBUTING.md
https://github.com/jsdoc3/jsdoc/blob/master/CODE_OF_CONDUCT.md
-->

| Q                | A                                                                |
| ---------------- | ---------------------------------------------------------------- |
| Bug fix?         | no                                                           |
| New feature?     |no                                                           |
| Breaking change? |no                                                           |
| Deprecations?    | no                                                           |
| Tests added?     | no                                                           |
| Fixed issues     | no |
| License          | Apache-2.0                                                       |

<!-- Describe your changes below in as much detail as possible. -->
clean-jsdoc-theme is one of the actively maintaining JSDoc theme libraries.
To see the theme visit: https://ankdev.me/clean-jsdoc-theme