### PR TITLE
Deal with HTML paragraphs, without an ending period

### DIFF
--- a/packages/jsdoc-plugins/summarize.js
+++ b/packages/jsdoc-plugins/summarize.js
@@ -28,10 +28,12 @@ export const handlers = {
     // If the summary is missing, grab the first sentence from the description
     // and use that.
     if (doclet && !doclet.summary && doclet.description) {
-      // The summary may end with `.$`, `. `, or `.<` (a period followed by an HTML tag).
-      doclet.summary = doclet.description.split(/\.$|\.\s|\.</)[0];
-      // Append `.` as it was removed in both cases, or is possibly missing.
-      doclet.summary += '.';
+      // The summary may end with:
+      // - `.$`
+      // - `. `
+      // - `.<` (a period followed by an HTML tag)
+      // - End of line (missing a . at the end of the sentence)
+      doclet.summary = doclet.description.split(/\.$|\.\s|\.<|\r?\n|\r/)[0];
 
       // This is an excerpt of something that is possibly HTML.
       // Balance it using a stack. Assume it was initially balanced.
@@ -66,6 +68,8 @@ export const handlers = {
       // and, finally, if the summary starts and ends with a <p> tag, remove it; let the
       // template decide whether to wrap the summary in a <p> tag
       doclet.summary = doclet.summary.replace(/^<p>(.*)<\/p>$/i, '$1');
+      // Append `.` as it was removed from the original first sentence, or is possibly missing.
+      doclet.summary += '.';
     }
   },
 };

--- a/packages/jsdoc-plugins/test/specs/summarize.js
+++ b/packages/jsdoc-plugins/test/specs/summarize.js
@@ -121,12 +121,32 @@ describe('summarize', () => {
 
       handler({ doclet: doclet });
 
-      expect(doclet.summary).toBe('This description has <em>a tag.</em>');
+      expect(doclet.summary).toBe('This description has <em>a tag</em>.');
     });
 
     it('should not include a <p> tag in the summary', () => {
       const doclet = {
         description: '<p>This description contains HTML.</p><p>And plenty of it!</p>',
+      };
+
+      handler({ doclet: doclet });
+
+      expect(doclet.summary).toBe('This description contains HTML.');
+    });
+
+    it('should not include a <p> tag in the summary when first sentence ends without .', () => {
+      const doclet = {
+        description: '<p>This description contains HTML</p>',
+      };
+
+      handler({ doclet: doclet });
+
+      expect(doclet.summary).toBe('This description contains HTML.');
+    });
+
+    it('should be no more than 1 line', () => {
+      const doclet = {
+        description: 'This description contains HTML\n\nFollow-up part of the description.',
       };
 
       handler({ doclet: doclet });


### PR DESCRIPTION
<!--
Before creating a pull request, please read our contributing guidelines and code of conduct:

https://github.com/jsdoc3/jsdoc/blob/master/CONTRIBUTING.md
https://github.com/jsdoc3/jsdoc/blob/master/CODE_OF_CONDUCT.md
-->

| Q                | A                                                                |
| ---------------- | ---------------------------------------------------------------- |
| Bug fix?         | yes/no                                                           | yes
| New feature?     | yes/no                                                           | no
| Breaking change? | yes/no                                                           | no
| Deprecations?    | yes/no                                                           | no
| Tests added?     | yes/no                                                           | yes
| Fixed issues     | comma-separated list of issues fixed by the pull request, if any | #1708 
| License          | Apache-2.0                                                       | yes

<!-- Describe your changes below in as much detail as possible. -->
It is pretty common for the markdown plugin to generate description where the first line is wrapped in `<p>`. There is already an existing line to deal with and remove these `<p>` explicitely.

This was however not working when the first line didn't end with a . The split caused `<p>summary</p>.` combinations because we force added a . after the non-matching split. This combination then subsequently did not match the `<p>` stripping regex at the end.

By force splitting on end of line we can avoid this mistake.