### PR TITLE
add `@legacy` tag

### DIFF
--- a/packages/jsdoc-doclet/lib/schema.js
+++ b/packages/jsdoc-doclet/lib/schema.js
@@ -352,6 +352,10 @@ export const DOCLET_SCHEMA = {
         'typedef',
       ],
     },
+    // is the symbol marked as legacy?
+    legacy: {
+      type: [STRING, BOOLEAN],
+    },
     license: {
       type: STRING,
     },

--- a/packages/jsdoc-tag/lib/definitions/closure.js
+++ b/packages/jsdoc-tag/lib/definitions/closure.js
@@ -68,6 +68,7 @@ export const getTags = (env) => {
       // Closure Compiler only
       synonyms: ['record'],
     }),
+    legacy: util.cloneTagDef(coreTags.legacy),
     lends: util.cloneTagDef(coreTags.lends),
     license: util.cloneTagDef(coreTags.license),
     modifies: util.cloneTagDef(coreTags.modifies),

--- a/packages/jsdoc-tag/lib/definitions/core.js
+++ b/packages/jsdoc-tag/lib/definitions/core.js
@@ -181,6 +181,12 @@ export const getTags = (env) => ({
       doclet.deprecated = value ?? true;
     },
   },
+  legacy: {
+    // value is optional
+    onTagged(doclet, { value }) {
+      doclet.legacy = value ?? true;
+    },
+  },
   enum: {
     canHaveType: true,
     onTagged(doclet, tag) {

--- a/packages/jsdoc/test/fixtures/legacytag.js
+++ b/packages/jsdoc/test/fixtures/legacytag.js
@@ -1,0 +1,11 @@
+/** @legacy
+*/
+function foo() {
+
+}
+
+/** @legacy use bar-v2 instead
+*/
+function bar() {
+
+}

--- a/packages/jsdoc/test/specs/tags/legacytag.js
+++ b/packages/jsdoc/test/specs/tags/legacytag.js
@@ -1,0 +1,28 @@
+/*
+  Copyright 2011 the JSDoc Authors.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+describe('@legacy tag', () => {
+  const docSet = jsdoc.getDocSetFromFile('test/fixtures/legacytag.js');
+  const foo = docSet.getByLongname('foo')[0];
+  const bar = docSet.getByLongname('bar')[0];
+
+  it('When a symbol has a @legacy tag with no value, the doclet has a legacy property set to true.', () => {
+    expect(foo.legacy).toBeTrue();
+  });
+
+  it('When a symbol has a @legacy tag with a value, the doclet has a legacy property set to that value.', () => {
+    expect(bar.legacy).toBe('use bar-v2 instead');
+  });
+});


### PR DESCRIPTION
<!--
Before creating a pull request, please read our contributing guidelines and code of conduct:

https://github.com/jsdoc3/jsdoc/blob/master/CONTRIBUTING.md
https://github.com/jsdoc3/jsdoc/blob/master/CODE_OF_CONDUCT.md
-->

| Q                | A                                                                |
| ---------------- | ---------------------------------------------------------------- |
| Bug fix?         | no                                                           |
| New feature?     | yes                                                           |
| Breaking change? | no                                                           |
| Deprecations?    | no                                                           |
| Tests added?     | yes                                                           |
| Fixed issues     | n/a |
| License          | Apache-2.0                                                       |

<!-- Describe your changes below in as much detail as possible. -->

The defintion of deprecation is to discourage use of code as it will be removed in future versions. See [defition and example #3 for Merriam Webster Dictionary](https://www.merriam-webster.com/dictionary/deprecate) and [defition and example #1 in the Oxford Dictionary of English](https://www.oxfordreference.com/display/10.1093/acref/9780199571123.001.0001/m_en_gb0217680?rskey=jQXadJ&result=23821).

However, [developers are using the deprecated tag to discorage use of code that will never be removed](https://x.com/colinhacks/status/1919477278641139989). A new legacy tag is better supported for use cases like that.
