### PR TITLE
Fix parsing hashbang TypeScript sources

### DIFF
--- a/packages/jsdoc-ast/lib/ast-builder.js
+++ b/packages/jsdoc-ast/lib/ast-builder.js
@@ -62,6 +62,7 @@ export const parserOptions = {
     'recordAndTuple',
     'sourcePhaseImports',
     'throwExpressions',
+    'typescript',
   ],
   ranges: true,
 };

--- a/packages/jsdoc-ast/test/specs/lib/ast-builder.js
+++ b/packages/jsdoc-ast/test/specs/lib/ast-builder.js
@@ -47,7 +47,7 @@ describe('@jsdoc/ast/lib/ast-builder', () => {
       // TODO: more tests
       it('logs (not throws) an error when a file cannot be parsed', () => {
         function parse() {
-          instance.build('qwerty!!!!!', 'bad.js');
+          instance.build('function (', 'bad.js');
         }
 
         expect(parse).not.toThrow();

--- a/packages/jsdoc-parse/test/specs/lib/parser.js
+++ b/packages/jsdoc-parse/test/specs/lib/parser.js
@@ -290,6 +290,19 @@ describe('@jsdoc/parse/lib/parser', () => {
 
         expect(parse).not.toThrow();
       });
+
+      it('parses TypeScript syntax after a POSIX hashbang at the start of the file', () => {
+        const parserSrc =
+          'javascript:#!/usr/bin/env node\n' +
+          'type Foo = string;\n' +
+          '/** @class */function Bar() {}';
+
+        attachTo(parser);
+        parser.parse(parserSrc);
+
+        expect(parser.results()).toBeArrayOfSize(1);
+        expect(parser.results()[0].longname).toBe('Bar');
+      });
     });
 
     describe('results', () => {


### PR DESCRIPTION
| Q                | A                                                                |
| ---------------- | ---------------------------------------------------------------- |
| Bug fix?         | yes                                                            |
| New feature?     | no                                                             |
| Breaking change? | no                                                             |
| Deprecations?    | no                                                             |
| Tests added?     | yes                                                            |
| Fixed issues     | #2166                                                          |
| License          | Apache-2.0                                                     |

This enables Babel's TypeScript parser plugin so TypeScript syntax after a POSIX hashbang is parsed instead of being reported as invalid JavaScript. It also adds a parser regression for a hashbang followed by a TypeScript type alias and keeps the AST-builder parse-error test valid now that TypeScript non-null assertions are accepted.

Verification:
- npm test
- npm run lint
- npx prettier --check packages/jsdoc-ast/lib/ast-builder.js packages/jsdoc-ast/test/specs/lib/ast-builder.js packages/jsdoc-parse/test/specs/lib/parser.js
- git diff --check