### PR TITLE
Add way to indicate that a function mutates its argument

### DIFF
--- a/packages/jsdoc-tag/lib/definitions/core.js
+++ b/packages/jsdoc-tag/lib/definitions/core.js
@@ -375,6 +375,7 @@ export const getTags = (env) => ({
   },
   modifies: {
     canHaveType: true,
+    canHaveName: true,
     onTagged(doclet, { value }) {
       doclet.modifies ??= [];
       doclet.modifies.push(value);

--- a/packages/jsdoc-template-legacy/tmpl/modifies.tmpl
+++ b/packages/jsdoc-template-legacy/tmpl/modifies.tmpl
@@ -18,6 +18,23 @@
 var data = obj || {};
 ?>
 
+<?js if (data.name) {?>
+<dl>
+    <dt>
+        Name
+    </dt>
+    <dd>
+        <code><?js= data.name ?></code>
+    </dd>
+</dl>
+<?js } ?>
+
+<?js if (data.description) {?>
+<div class="param-desc">
+    <?js= data.description ?>
+</div>
+<?js } ?>
+
 <?js if (data.type && data.type.names) {?>
 <dl>
     <dt>

--- a/packages/jsdoc/test/fixtures/modifiestag.js
+++ b/packages/jsdoc/test/fixtures/modifiestag.js
@@ -3,3 +3,11 @@
  * @modifies {(foo|bar)}
  */
 function mutator(foo, bar) {}
+
+/**
+ * Add extra details to peeps.
+ *
+ * @param {Array<string>} peeps - Peep IDs to augment.
+ * @modifies peeps - Adds extra details to each peep.
+ */
+function augmentPeeps(peeps) {}

--- a/packages/jsdoc/test/specs/tags/modifiestag.js
+++ b/packages/jsdoc/test/specs/tags/modifiestag.js
@@ -16,6 +16,7 @@
 describe('@modifies tag', () => {
   const docSet = jsdoc.getDocSetFromFile('test/fixtures/modifiestag.js');
   const mutator = docSet.getByLongname('mutator')[0];
+  const augmentPeeps = docSet.getByLongname('augmentPeeps')[0];
 
   it("should add the specified types to the doclet's `modifies` property", () => {
     expect(mutator.modifies).toBeArrayOfSize(1);
@@ -23,5 +24,11 @@ describe('@modifies tag', () => {
     expect(mutator.modifies[0].type.names).toBeArrayOfSize(2);
     expect(mutator.modifies[0].type.names[0]).toBe('foo');
     expect(mutator.modifies[0].type.names[1]).toBe('bar');
+  });
+
+  it("should add the specified parameter name and description to the doclet's `modifies` property", () => {
+    expect(augmentPeeps.modifies).toBeArrayOfSize(1);
+    expect(augmentPeeps.modifies[0].name).toBe('peeps');
+    expect(augmentPeeps.modifies[0].description).toBe('Adds extra details to each peep.');
   });
 });


### PR DESCRIPTION
## Summary
- Implements the maintainer-requested feature from https://github.com/jsdoc/jsdoc/issues/833.
- Scope: Add way to indicate that a function mutates its argument

## Verification
- Manual verification notes required before maintainer review.

## Notes
- This intentionally extends the existing `@modifies` tag rather than adding a new `@mutates` or `@sideeffects` tag, avoiding a broader/speculative tag design.
- Open issue #1709 separately asks to document `@modifies`; this candidate does not add standalone docs because the current default branch has no `docs/` tag documentation tree and the narrow feature value is parser/template behavior for #833.