### PR TITLE
docs: align README Node.js requirement with package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Want to contribute to JSDoc? Please read [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 ## Installation and Usage
 
-JSDoc supports stable versions of Node.js 8.15.0 and later. You can install
+JSDoc supports stable versions of Node.js 22.13.0 and later. You can install
 JSDoc globally or in your project's `node_modules` folder.
 
 To install the latest version on npm globally (might require `sudo`;


### PR DESCRIPTION
Hi team,

I noticed the README still says Node.js 8.15.0 and later is required, but package.json already lists ^22.13.0 || >=23.0.0 in the engines field. This PR updates the README to match that, so new contributors don't get misled by the old minimum.

Change:

README Node.js requirement updated from >= 8.15.0 to >= 22.13.0 to align with package.json.
Let me know if anything else is needed.