### PR TITLE
Merge .defails ul into one selector

### DIFF
--- a/packages/jsdoc-template-legacy/static/styles/jsdoc-default.css
+++ b/packages/jsdoc-template-legacy/static/styles/jsdoc-default.css
@@ -272,8 +272,6 @@ header .signature {
 }
 .details ul {
   margin: 0;
-}
-.details ul {
   list-style-type: none;
 }
 .details li {


### PR DESCRIPTION
<!--
Before creating a pull request, please read our contributing guidelines and code of conduct:

https://github.com/jsdoc3/jsdoc/blob/master/CONTRIBUTING.md
https://github.com/jsdoc3/jsdoc/blob/master/CODE_OF_CONDUCT.md
-->

| Q                | A                                                                |
| ---------------- | ---------------------------------------------------------------- |
| Bug fix?         | yes                                                          |
| New feature?     | no                                                           |
| Breaking change? | no                                                           |
| Deprecations?    | yes                                                           |
| Tests added?     | no                                                           |
| Fixed issues     | #2177  |
| License          | Apache-2.0                                                       |

<!-- Describe your changes below in as much detail as possible. -->
  
### Changes  

Merge two instances of css selector **.details ul** into one. Possible remove or replace of **tt** on line 59, will also be added after discussion