### PR TITLE
docs: fix dead template example links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ and customize your documentation. Here are a few of them:
 - [docdash](https://github.com/clenemt/docdash)
   ([example](http://clenemt.github.io/docdash/))
 - [tui-jsdoc-template](https://github.com/nhnent/tui.jsdoc-template)
-  ([example](https://nhnent.github.io/tui.jsdoc-template/latest/))
+  ([example](https://nhn.github.io/tui.jsdoc-template/latest/))
 - [better-docs](https://github.com/SoftwareBrothers/better-docs)
-  ([example](https://softwarebrothers.github.io/admin-bro-dev/index.html))
+  ([example](https://softwarebrothers.github.io/example-design-system/index.html))
 
 ### Build tools
 


### PR DESCRIPTION
Two template "example" links in the README are dead:

1. **tui.jsdoc-template** — the NHN Entertainment org was renamed (`nhnent` → `nhn`), so the GitHub Pages demo moved: `https://nhn.github.io/tui.jsdoc-template/latest/` (HTTP 200).
2. **better-docs** — the old `admin-bro-dev` demo is gone; better-docs' own README now points to `https://softwarebrothers.github.io/example-design-system/index.html` (HTTP 200) as its example documentation.
